### PR TITLE
Release 0.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,13 @@
+0.12.0
+======
+
+- Removes deprecated API.
+- Minor housekeeping moving to a new home at github.com/data61/anonlink
+- PyPi release should be automatically made by travis-ci
+
 0.11.2
 ======
+
 - Fixes an issue that caused the loading functions in `anonlink.serialization` to raise when loading from Minio objects.
 
 0.11.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -212,7 +212,7 @@ Other improvements
 - Internal C/C++ cleanup/refactoring and optimization.
 - Expose the native popcount implementation to Python.
 - Bug fix to avoid configuring a logger.
-- Testing is now with `py.test` and runs on [travis-ci](https://travis-ci.org/n1analytics/anonlink/)
+- Testing is now with `py.test` and runs on [travis-ci](https://travis-ci.org/data61/anonlink/)
 
 0.6.3
 =====

--- a/Jenkinsfile.groovy
+++ b/Jenkinsfile.groovy
@@ -1,4 +1,4 @@
-@Library("N1Pipeline@0.0.5")
+@Library("N1Pipeline@0.0.24")
 import com.n1analytics.git.GitUtils;
 import com.n1analytics.git.GitCommit;
 import com.n1analytics.n1.docker.N1EngineContainer;

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 
-.. image:: https://travis-ci.org/n1analytics/anonlink.svg?branch=master
-    :target: https://travis-ci.org/n1analytics/anonlink
+.. image:: https://travis-ci.org/data61/anonlink.svg?branch=master
+    :target: https://travis-ci.org/data61/anonlink
 
 
 A Python (and optimised C++) implementation of **anonymous linkage** using
@@ -11,7 +11,7 @@ Code <http://www.record-linkage.de/-download=wp-grlc-2011-02.pdf>`__.
 Computes similarity scores, and/or best guess matches between two sets
 of *cryptographic linkage keys* (hashed entity records).
 
-Use `clkhash <https://github.com/n1analytics/clkhash>`__ to create cryptographic linkage keys
+Use `clkhash <https://github.com/data61/clkhash>`__ to create cryptographic linkage keys
 from personally identifiable data.
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',
-    url='https://github.com/n1analytics/anonlink',
+    url='https://github.com/data61/anonlink',
     license='Apache',
     setup_requires=['cffi>=1.7'],
     install_requires=requirements,


### PR DESCRIPTION
Some changes landed in master instead of develop, so just to get everything squared away this is a small release that deprecates the old api, adds automated uploads to pypi and updates the projects links to the data61 github.

After review I'll open a PR bring all the changes into master