### PR TITLE
Fix travis not actually requiring tests or typing to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,16 @@ python:
 env:
 
 install:
-  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install -U mypy; fi
   - travis_retry pip install -U pytest pytest-cov
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py sdist bdist_wheel
   - travis_retry pip install -e .
 
 script:
-  - if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
   - pytest --cov=anonlink -W ignore::DeprecationWarning
 
 jobs:
-  #fast_finish: true
+  fast_finish: true
   allow_failures:
     - python: "3.8-dev"
     - python: "nightly"
@@ -50,8 +48,10 @@ jobs:
     - stage: test
       name: "Typecheck"
       python: "3.7"
-      env:
-        - MYPY_TYPING=1
+      before_install:
+        - travis_retry pip install -U mypy
+      script:
+        - mypy anonlink --ignore-missing-imports
     - stage: Build wheels
       sudo: required
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ jobs:
     # No matrix support in Stages
     # Stages with the same name get run in parallel. Jobs within a stage can also be named.
     - stage: test
-    - stage: test
       name: "Extended Size 10K"
       python: "3.7"
       env:
@@ -58,10 +57,9 @@ jobs:
       python: "3.6"
       services:
       - docker
-      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-      install: docker pull $DOCKER_IMAGE
+      install: docker pull quay.io/pypa/manylinux1_x86_64
       script:
-      - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
+      - docker run --rm -v `pwd`:/io quay.io/pypa/manylinux1_x86_64 /io/travis/build-wheels.sh
       - ls wheelhouse/
       deploy:
         provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,17 @@ jobs:
     - python: "pypy3"
   include:
     # No matrix support in Stages
-    # Stages with the same name get run in parallel
+    # Stages with the same name get run in parallel. Jobs within a stage can also be named.
     - stage: test
+    - stage: test
+      name: "Extended Size"
+      env:
+        - INCLUDE_10K=1
+        #- INCLUDE_100K=1
       name: "Typecheck"
-      python: "3.6"
+      python: "3.7"
       env:
         - MYPY_TYPING=1
-          INCLUDE_10K=1
     - stage: Build wheels
       sudo: required
       python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
 env:
 
 install:
-  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install -U mypy mypy-extensions; fi
+  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install -U mypy; fi
   - travis_retry pip install -U pytest pytest-cov
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,51 @@ cache:
   directories:
   - "$HOME/.cache/pip"
 
-matrix:
-  fast_finish: true   # https://docs.travis-ci.com/user/build-matrix/#fast-finishing
-  include:
-  - python: 3.6
-    env:
-    - MYPY_TYPING=1
-    - INCLUDE_10K=1
-  - python: 3.7
-  - python: 3.8-dev
-  - python: nightly
-  - python: pypy3
-    dist: trusty
+python:
+- 3.7
+- 3.8-dev
+- nightly
+- pypy3
 
-  allow_failures:
-  - python: 3.8-dev
-  - python: nightly
-  - python: pypy3
+env:
+  - MYPY_TYPING=1
+    INCLUDE_10K=1
+
+# matrix doesn't work with stages....
+#matrix:
+#  fast_finish: true   # https://docs.travis-ci.com/user/build-matrix/#fast-finishing
+#  include:
+#  - python: 3.6
+#    env:
+#    - MYPY_TYPING=1
+#    - INCLUDE_10K=1
+#  - python: 3.7
+#  - python: 3.8-dev
+#  - python: nightly
+#  - python: pypy3
+#    dist: trusty
+
+install:
+  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
+  - travis_retry pip install pytest pytest-cov
+  - if [ -n "$USE_ASV" ]; then pip install asv; fi
+  - travis_retry pip install -r requirements.txt
+  - travis_retry python setup.py sdist bdist_wheel
+  - travis_retry pip install -e .
+
+script:
+  - if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
+  - pytest --cov=anonlink -W ignore::DeprecationWarning
 
 jobs:
   include:
-    - stage: Test
+    # No matrix support in Stages
+    # Stages with the same name get run in parallel
+    - stage: test
+      allow_failures:
+        - python: 3.8-dev
+        - python: nightly
+        - python: pypy3
     - stage: Build wheels
       sudo: required
       python: '3.6'
@@ -45,15 +69,3 @@ jobs:
           secure: rRlPkjKaI/HIkA/HEagWgFyqZ6ds+yZWiYAsGHuop3DAGFKRjtDkvj+ukCoL0Tmz66PxyKp0wEEstA+RwdbkMkOPHGs7zraoRevETI2nrbmNLyipSlXrPIfm8Tru5mMQVMVXuKYfJwu4SnWZzd/Yd+E1wiLRU4IcACTyt1w9aSrDN122+Xgvq8/b9sJNp1VMaD/3ca4xBjuYlCH6FITjH1NCWL5ETguupoKF2kzXztSnO5jZhSfeGNe4yDoOymOKInaVy4Wog5HX0SbHAEuC13PxZn5HftSR4kwtuO0WZLZKX1qap6Vo06aQ9x+epR2ZtAdS0eHp/DaONSyCaKj9/bxYlSc45a2wnM4SgG0fX8MhCt2qHGnntXVcb60y3guEwb/uiI7yPAoG7sHcqdRCLLPYMzrKKmde83ElF29LMOf6MDfnfR+O1F1PDXZfzSi/bKUo42J6XrH8i5eDIRgS6kIGNncO4QoU7RHW+KoUPIZE9NfnPVkYNmc8m8O3Er5UF4OeIc/1SRouhq1hdb3VvahnXRWmHo1EYMYeKcVE6HVwkopnwWbs788ANl/lj8QlNY5jfPxWcEAqrhl9UfgFwgz7RAbYs04asqf3RvqX3NabfoeqtLzXMrq7ajdOMJuDhS7ody5aHzXj7rP/9K8Rju7qKeuVIf4VqJ1iKz2n1Q8=
         on:
           tags: true
-
-install:
-  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
-  - travis_retry pip install pytest pytest-cov
-  - if [ -n "$USE_ASV" ]; then pip install asv; fi
-  - travis_retry pip install -r requirements.txt
-  - travis_retry python setup.py sdist bdist_wheel
-  - travis_retry pip install -e .
-
-script:
-  - if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
-  - pytest --cov=anonlink -W ignore::DeprecationWarning

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ python:
 env:
 
 install:
-  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
+  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy mypy-extensions>=0.3; fi
   - travis_retry pip install pytest pytest-cov
   - if [ -n "$USE_ASV" ]; then pip install asv; fi
   - travis_retry pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ python:
 env:
 
 install:
-  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy mypy-extensions>=0.3; fi
-  - travis_retry pip install pytest pytest-cov
-  - if [ -n "$USE_ASV" ]; then pip install asv; fi
+  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install -U mypy mypy-extensions; fi
+  - travis_retry pip install -U pytest pytest-cov
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py sdist bdist_wheel
   - travis_retry pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,22 @@ jobs:
     - python: "3.8-dev"
     - python: "nightly"
     - python: "pypy3"
+    - name: "Extended 100K"
   include:
     # No matrix support in Stages
     # Stages with the same name get run in parallel. Jobs within a stage can also be named.
     - stage: test
     - stage: test
-      name: "Extended Size"
+      name: "Extended Size 10K"
+      python: "3.7"
       env:
         - INCLUDE_10K=1
-        #- INCLUDE_100K=1
+    - stage: test
+      name: "Extended Size 100K"
+      python: "3.7"
+      env:
+        - INCLUDE_100K=1
+    - stage: test
       name: "Typecheck"
       python: "3.7"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,22 +15,6 @@ python:
 - pypy3
 
 env:
-  - MYPY_TYPING=1
-    INCLUDE_10K=1
-
-# matrix doesn't work with stages....
-#matrix:
-#  fast_finish: true   # https://docs.travis-ci.com/user/build-matrix/#fast-finishing
-#  include:
-#  - python: 3.6
-#    env:
-#    - MYPY_TYPING=1
-#    - INCLUDE_10K=1
-#  - python: 3.7
-#  - python: 3.8-dev
-#  - python: nightly
-#  - python: pypy3
-#    dist: trusty
 
 install:
   - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
@@ -47,20 +31,21 @@ script:
 jobs:
   #fast_finish: true
   allow_failures:
-    - python: 3.8-dev
-    - python: nightly
-    - python: pypy3
+    - python: "3.8-dev"
+    - python: "nightly"
+    - python: "pypy3"
   include:
     # No matrix support in Stages
     # Stages with the same name get run in parallel
     - stage: test
-      allow_failures:
-        - python: 3.8-dev
-        - python: nightly
-        - python: pypy3
+      name: "Typecheck"
+      python: "3.6"
+      env:
+        - MYPY_TYPING=1
+          INCLUDE_10K=1
     - stage: Build wheels
       sudo: required
-      python: '3.6'
+      python: "3.6"
       services:
       - docker
       env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,59 @@
+
+dist: xenial   # required for Python >= 3.7
 language: python
 sudo: false
-python:
-- 3.7-dev
-- nightly
-- pypy3
-env:
-- INCLUDE_10K=
+
+cache:
+  directories:
+  - "$HOME/.cache/pip"
+
 matrix:
-  allow_failures:
-  - python: 3.7-dev
-  - python: nightly
-  - python: pypy3
+  fast_finish: true   # https://docs.travis-ci.com/user/build-matrix/#fast-finishing
   include:
-  - python: '3.6'
+  - python: 3.6
     env:
     - MYPY_TYPING=1
+    - INCLUDE_10K=1
+  - python: 3.7
+  - python: 3.8-dev
+  - python: nightly
+  - python: pypy3
+    dist: trusty
+
+  allow_failures:
+  - python: 3.8-dev
+  - python: nightly
+  - python: pypy3
+
 jobs:
   include:
-  - stage: Build wheels
-    sudo: required
-    python: '3.6'
-    services:
-    - docker
-    env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
-    install: docker pull $DOCKER_IMAGE
-    script:
-    - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
-    - ls wheelhouse/
-    deploy:
-      provider: pypi
-      user: confidentialcomputing
-      password:
-        secure: rRlPkjKaI/HIkA/HEagWgFyqZ6ds+yZWiYAsGHuop3DAGFKRjtDkvj+ukCoL0Tmz66PxyKp0wEEstA+RwdbkMkOPHGs7zraoRevETI2nrbmNLyipSlXrPIfm8Tru5mMQVMVXuKYfJwu4SnWZzd/Yd+E1wiLRU4IcACTyt1w9aSrDN122+Xgvq8/b9sJNp1VMaD/3ca4xBjuYlCH6FITjH1NCWL5ETguupoKF2kzXztSnO5jZhSfeGNe4yDoOymOKInaVy4Wog5HX0SbHAEuC13PxZn5HftSR4kwtuO0WZLZKX1qap6Vo06aQ9x+epR2ZtAdS0eHp/DaONSyCaKj9/bxYlSc45a2wnM4SgG0fX8MhCt2qHGnntXVcb60y3guEwb/uiI7yPAoG7sHcqdRCLLPYMzrKKmde83ElF29LMOf6MDfnfR+O1F1PDXZfzSi/bKUo42J6XrH8i5eDIRgS6kIGNncO4QoU7RHW+KoUPIZE9NfnPVkYNmc8m8O3Er5UF4OeIc/1SRouhq1hdb3VvahnXRWmHo1EYMYeKcVE6HVwkopnwWbs788ANl/lj8QlNY5jfPxWcEAqrhl9UfgFwgz7RAbYs04asqf3RvqX3NabfoeqtLzXMrq7ajdOMJuDhS7ody5aHzXj7rP/9K8Rju7qKeuVIf4VqJ1iKz2n1Q8=
-      on:
-        tags: true
+    - stage: Test
+    - stage: Build wheels
+      sudo: required
+      python: '3.6'
+      services:
+      - docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux1_x86_64
+      install: docker pull $DOCKER_IMAGE
+      script:
+      - docker run --rm -v `pwd`:/io $DOCKER_IMAGE /io/travis/build-wheels.sh
+      - ls wheelhouse/
+      deploy:
+        provider: pypi
+        user: confidentialcomputing
+        password:
+          secure: rRlPkjKaI/HIkA/HEagWgFyqZ6ds+yZWiYAsGHuop3DAGFKRjtDkvj+ukCoL0Tmz66PxyKp0wEEstA+RwdbkMkOPHGs7zraoRevETI2nrbmNLyipSlXrPIfm8Tru5mMQVMVXuKYfJwu4SnWZzd/Yd+E1wiLRU4IcACTyt1w9aSrDN122+Xgvq8/b9sJNp1VMaD/3ca4xBjuYlCH6FITjH1NCWL5ETguupoKF2kzXztSnO5jZhSfeGNe4yDoOymOKInaVy4Wog5HX0SbHAEuC13PxZn5HftSR4kwtuO0WZLZKX1qap6Vo06aQ9x+epR2ZtAdS0eHp/DaONSyCaKj9/bxYlSc45a2wnM4SgG0fX8MhCt2qHGnntXVcb60y3guEwb/uiI7yPAoG7sHcqdRCLLPYMzrKKmde83ElF29LMOf6MDfnfR+O1F1PDXZfzSi/bKUo42J6XrH8i5eDIRgS6kIGNncO4QoU7RHW+KoUPIZE9NfnPVkYNmc8m8O3Er5UF4OeIc/1SRouhq1hdb3VvahnXRWmHo1EYMYeKcVE6HVwkopnwWbs788ANl/lj8QlNY5jfPxWcEAqrhl9UfgFwgz7RAbYs04asqf3RvqX3NabfoeqtLzXMrq7ajdOMJuDhS7ody5aHzXj7rP/9K8Rju7qKeuVIf4VqJ1iKz2n1Q8=
+        on:
+          tags: true
 
 install:
-- if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
-- travis_retry pip install pytest pytest-cov
-- if [ -n "$USE_ASV" ]; then pip install asv; fi
-- travis_retry pip install -r requirements.txt
-- travis_retry python setup.py sdist bdist_wheel
-- travis_retry pip install -e .
-script:
-- if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
-- pytest --cov=anonlink -W ignore::DeprecationWarning
+  - if [ "${MYPY_TYPING}" == "1" ]; then travis_retry pip install mypy; fi
+  - travis_retry pip install pytest pytest-cov
+  - if [ -n "$USE_ASV" ]; then pip install asv; fi
+  - travis_retry pip install -r requirements.txt
+  - travis_retry python setup.py sdist bdist_wheel
+  - travis_retry pip install -e .
 
+script:
+  - if [ "${MYPY_TYPING}" == "1" ]; then mypy anonlink --ignore-missing-imports; fi
+  - pytest --cov=anonlink -W ignore::DeprecationWarning

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   - "$HOME/.cache/pip"
 
 python:
+- 3.6
 - 3.7
 - 3.8-dev
 - nightly
@@ -44,6 +45,11 @@ script:
   - pytest --cov=anonlink -W ignore::DeprecationWarning
 
 jobs:
+  #fast_finish: true
+  allow_failures:
+    - python: 3.8-dev
+    - python: nightly
+    - python: pypy3
   include:
     # No matrix support in Stages
     # Stages with the same name get run in parallel

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ You can run the benchmark with:
 
 ::
 
-    $ python3 -m anonlink.benchmark
+    $ python -m anonlink.benchmark
     Anonlink benchmark -- see README for explanation
     ------------------------------------------------
     100000 x 1024 bit popcounts
@@ -154,11 +154,13 @@ Limitations
 Discussion
 ----------
 
-If you run into bugs, you can file them in our [issue tracker](https://github.com/data61/anonlink/issues) on GitHub.
+If you run into bugs, you can file them in our `issue tracker <https://github.com/data61/anonlink/issues>`__
+on GitHub.
 
-There is also an [anonlink mailing list](https://groups.google.com/forum/#!forum/anonlink) for development discussion and release announcements.
+There is also an `anonlink mailing list <https://groups.google.com/forum/#!forum/anonlink>`__
+for development discussion and release announcements.
 
-Wherever we interact, we strive to follow the [Python Community Code of Conduct](https://www.python.org/psf/codeofconduct/).
+Wherever we interact, we strive to follow the `Python Community Code of Conduct <https://www.python.org/psf/codeofconduct/>`__.
 
 
 License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bitarray==0.8.1
-networkx==1.11
 cffi>=1.7
 pytest>=3.4
 pytest-cov>=2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ pytest>=3.4
 pytest-cov>=2.5
 clkhash==0.11.0
 numpy==1.15.3
-mypy-extensions==0.3.0
+mypy-extensions==0.4.1
 hypothesis==3.69.2
 Cython==0.28.5

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = [
         "bitarray>=0.8.1",
-        "networkx>=1.11,<=2",
         "cffi>=1.7",
         "clkhash>=0.11",
         "numpy>=1.14",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,8 +12,6 @@ from clkhash.key_derivation import generate_key_lists
 import anonlink
 import anonlink.benchmark
 
-__author__ = 'Brian Thorne'
-
 
 def generate_data(samples, proportion=0.75):
     nl = randomnames.NameList(samples * 2)
@@ -129,7 +127,7 @@ class TestEntityMatchingE2E_1K(EntityHelperTestMixin, unittest.TestCase):
 
 @unittest.skipUnless("INCLUDE_10K" in os.environ,
                      "Set envvar INCLUDE_10K to run")
-class TestEntityMatchingE2E_10k(EntityHelperMixin, unittest.TestCase):
+class TestEntityMatchingE2E_10k(EntityHelperTestMixin, unittest.TestCase):
 
     sample = 10000
     proportion = 0.7
@@ -137,26 +135,16 @@ class TestEntityMatchingE2E_10k(EntityHelperMixin, unittest.TestCase):
     def setUp(self):
         self.s1, self.s2, self.filters1, self.filters2 = generate_data(self.sample, self.proportion)
 
-    def test_greedy(self):
-        mapping = entitymatch.calculate_mapping_greedy(
-            self.filters1, self.filters2, self.default_greedy_k, self.default_greedy_threshold)
-        self.check_accuracy(mapping)
-
 
 @unittest.skipUnless("INCLUDE_100K" in os.environ,
                      "Set envvar INCLUDE_100K to run")
-class TestEntityMatchingE2E_100k(EntityHelperMixin, unittest.TestCase):
+class TestEntityMatchingE2E_100k(EntityHelperTestMixin, unittest.TestCase):
 
     sample = 100000
     proportion = 0.9
 
     def setUp(self):
         self.s1, self.s2, self.filters1, self.filters2 = generate_data(self.sample, self.proportion)
-
-    def test_greedy(self):
-        mapping = entitymatch.calculate_mapping_greedy(
-            self.filters1, self.filters2, self.default_greedy_k, self.default_greedy_threshold)
-        self.check_accuracy(mapping)
 
 
 class TestEntityMatchTopK(EntityHelperMixin, unittest.TestCase):


### PR DESCRIPTION
Bit of a n00b mistake, turns out Travis jobs, matrix builds and stages are not all compatible with each other.

I've cleaned up the travis file a bit. Changes:
- replaced Python `3.7-dev' with `3.7`
- added Python `3.8-dev`
- updated mypy extensions as the pinned version had a bug
- added in a `100K` sized job (which is allowed to fail)
- removed a couple of tests that used the deprecated `entitymatch.calculate_mapping_greedy`.