### PR TITLE
Add coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+# Validate with curl --data-binary @.codecov.yml https://codecov.io/validate
+coverage:
+  precision: 2
+  round: down
+  range: 90...100
+  status:
+    # pull-requests only
+    patch:
+      default:
+        # coverage may fall by <2.0% and still be considered "passing"
+        threshold: 2.0%
+
+comment:
+  layout: "header, diff, changes"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ python:
 env:
 
 install:
-  - travis_retry pip install -U pytest pytest-cov
   - travis_retry pip install -r requirements.txt
   - travis_retry python setup.py sdist bdist_wheel
-  - travis_retry pip install -e .
+  - travis_retry pip install -e .[test]
 
 script:
   - pytest --cov=anonlink -W ignore::DeprecationWarning
+  - codecov
 
 jobs:
   fast_finish: true

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,10 @@
     :target: https://travis-ci.org/data61/anonlink
 
 
+.. image:: https://codecov.io/gh/data61/anonlink/branch/master/graph/badge.svg
+  :target: https://codecov.io/gh/data61/anonlink
+
+
 A Python (and optimised C++) implementation of **anonymous linkage** using
 *cryptographic linkage keys* as described by Rainer Schnell, Tobias
 Bachteler, and Jörg Reiher in `A Novel Error-Tolerant Anonymous Linking

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,13 @@ requirements = [
         "mypy-extensions>=0.3"
     ]
 
+test_requirements = [
+        "pytest",
+        "pytest-timeout",
+        "pytest-cov",
+        "codecov"
+    ]
+
 extensions = [Extension(
     name="solving._multiparty_solving",
     sources=["anonlink/solving/_multiparty_solving." + cython_cpp_ext,
@@ -44,8 +51,12 @@ setup(
     long_description_content_type='text/x-rst',
     url='https://github.com/data61/anonlink',
     license='Apache',
-    setup_requires=['cffi>=1.7'],
+    setup_requires=["cffi>=1.7", "pytest-runner"],
     install_requires=requirements,
+    tests_require=test_requirements,
+    extras_require={
+        "test": test_requirements
+    },
     packages=find_packages(exclude=[
         '_cffi_build', '_cffi_build/*',
         'tests'
@@ -65,6 +76,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Security :: Cryptography",


### PR DESCRIPTION
Adds support for publishing the code coverage to codecov.io similar to what we do for clkhash.

Example coverage report [here](https://codecov.io/gh/data61/anonlink/tree/194ecb6ded9bdea66899b28ba7ed3e9d2f0e555d/anonlink).

Screenshot:
![image](https://user-images.githubusercontent.com/855189/56846553-04110f00-6914-11e9-9abc-f3287a599656.png)

Once we install the codecov GitHub appliction (I can't myself) the bot should comment on PRs that lower the code coverage.