### PR TITLE
add cython dep to setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ extensions = [Extension(
     name="solving._multiparty_solving",
     sources=["anonlink/solving/_multiparty_solving." + cython_cpp_ext,
              "anonlink/solving/_multiparty_solving_inner.cpp"],
-    # include=["anonlink/solving/_multiparty_solving_inner.h"],
     include_dirs=["anonlink/solving"],
     language="c++",
     extra_compile_args=["-std=c++11"],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, Extension, find_packages
 import os
 
+from Cython.Build import cythonize, build_ext
 try:
     from Cython.Build import cythonize, build_ext
 except ImportError:
@@ -33,7 +34,8 @@ extensions = [Extension(
     name="solving._multiparty_solving",
     sources=["anonlink/solving/_multiparty_solving." + cython_cpp_ext,
              "anonlink/solving/_multiparty_solving_inner.cpp"],
-    include=["anonlink/solving/_multiparty_solving_inner.h"],
+    # include=["anonlink/solving/_multiparty_solving_inner.h"],
+    include_dirs=["anonlink/solving"],
     language="c++",
     extra_compile_args=["-std=c++11"],
     extra_link_args=["-std=c++11"],

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup, Extension, find_packages
 import os
 
-from Cython.Build import cythonize, build_ext
 try:
     from Cython.Build import cythonize, build_ext
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ requirements = [
         "cffi>=1.7",
         "clkhash>=0.11",
         "numpy>=1.14",
-        "mypy-extensions>=0.3"
+        "mypy-extensions>=0.3",
+        "Cython>=0.29.10"
     ]
 
 test_requirements = [


### PR DESCRIPTION
Looks like this fixes the vanilla install (as referenced in #220). Might also be worth adding a warning about missing Cython in setup.py too, rather than just catching the ImportError and carrying on... what do you think?