### PR TITLE
towards more inclusive releases

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,4 @@ exclude .jenkins
 # Include Cython code
 global-include *.pyx
 global-include *.pxd
+include anonlink/solving/_multiparty_solving_inner.h


### PR DESCRIPTION
the tar.gz release was broken, as it didn't contain the C header file.