### PR TITLE
steadying hypothesis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ pytest-cov>=2.5
 clkhash==0.13.0
 numpy==1.16.4
 mypy-extensions==0.4.1
-hypothesis==3.69.2
+hypothesis==4.33.0
 Cython==0.29.10

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ test_requirements = [
         "pytest",
         "pytest-timeout",
         "pytest-cov",
-        "codecov"
+        "codecov",
+        "hypothesis"
     ]
 
 extensions = [Extension(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+
+# in some tests we map hypothesis produced integers to 'unsigned int' arrays. Thus we have to tell hypothesis to only
+# produce suitable numbers.
+UINT_MAX = 2**32 - 1

--- a/tests/test_solving.py
+++ b/tests/test_solving.py
@@ -3,12 +3,14 @@ from array import array
 from collections import Counter
 
 import pytest
-from hypothesis import given, reject, strategies
+from hypothesis import given, strategies
 
 from anonlink.solving import (
     greedy_solve, greedy_solve_python, greedy_solve_native, pairs_from_groups,
     probabilistic_greedy_solve, probabilistic_greedy_solve_native,
     probabilistic_greedy_solve_python)
+from tests import UINT_MAX
+
 
 def _zip_candidates(candidates):
     candidates = tuple(candidates)
@@ -186,8 +188,8 @@ def dict_to_candidate_pairs(candidate_dict):
 
 
 indices_np = strategies.tuples(
-    strategies.integers(min_value=0),
-    strategies.integers(min_value=0))
+    strategies.integers(min_value=0, max_value=UINT_MAX),
+    strategies.integers(min_value=0, max_value=UINT_MAX))
 index_pair_np = strategies.tuples(
         indices_np, indices_np
     ).filter(
@@ -228,9 +230,9 @@ def test_greedy_np(candidate_pairs):
 
 
 indices0_2p = strategies.tuples(strategies.just(0),
-                          strategies.integers(min_value=0))
+                          strategies.integers(min_value=0, max_value=UINT_MAX))
 indices1_2p = strategies.tuples(strategies.just(1),
-                          strategies.integers(min_value=0))
+                          strategies.integers(min_value=0, max_value=UINT_MAX))
 index_pair_2p = strategies.tuples(indices0_2p, indices1_2p)
 candidate_pairs_2p = strategies.dictionaries(
         index_pair_2p,

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -4,6 +4,7 @@ import hypothesis
 import pytest
 
 import anonlink
+from tests import UINT_MAX
 
 
 def zip_candidates(candidates):
@@ -38,10 +39,10 @@ def dict_to_candidate_pairs(candidate_dict):
 
 indices0_2p = hypothesis.strategies.tuples(
     hypothesis.strategies.just(0),
-    hypothesis.strategies.integers(min_value=0))
+    hypothesis.strategies.integers(min_value=0, max_value=UINT_MAX))
 indices1_2p = hypothesis.strategies.tuples(
     hypothesis.strategies.just(1),
-    hypothesis.strategies.integers(min_value=0))
+    hypothesis.strategies.integers(min_value=0, max_value=UINT_MAX))
 index_pair_2p = hypothesis.strategies.tuples(indices0_2p, indices1_2p)
 candidate_pairs_2p = hypothesis.strategies.dictionaries(
         index_pair_2p,
@@ -99,6 +100,8 @@ def test_cumul_number_matches_vs_threshold(candidate_pairs, steps):
                       min_value=1,
                       max_value=100,  # Linear in this
                       ))
+#@hypothesis.example(((0.5325659332756726, ((0, 97), (1, 628))), (0.08830395403829218, ((0, 5052346094), (1, 340))), (0.023114404426094696, ((0, 34975), (1, 725)))), 3
+#)
 def test_matches_nonmatches_hist(candidate_pairs, bins):
     hist = anonlink.stats.matches_nonmatches_hist(
         candidate_pairs, bins=bins)


### PR DESCRIPTION
with some not quite so old version of hypothesis, they introduced that the `integers` strategies can produce integers of a length of up to 128 bits.
This caused a problem in our tests, as we map those integers to `array.array('I')` which can only hold an unsigned int 32 bits).


fixes #210