### PR TITLE
Build and test wheel for each Python version in manylinux container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
         - mypy anonlink --ignore-missing-imports
     - stage: Build wheels
       sudo: required
-      if: tag IS present
+      #if: tag IS present
       python: "3.6"
       services:
       - docker

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink",
-    version='0.12.4',
+    version='0.12.5a1',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',

--- a/travis/build-dist.sh
+++ b/travis/build-dist.sh
@@ -9,7 +9,6 @@ yum install -y atlas-devel
 ls /opt/python/
 
 listOfPythons="
-cp35-cp35m
 cp36-cp36m
 cp37-cp37m"
 

--- a/travis/build-dist.sh
+++ b/travis/build-dist.sh
@@ -4,6 +4,8 @@
 
 set -e -x
 
+yum install -y atlas-devel
+
 ls /opt/python/
 
 # Compile wheels for each Python version

--- a/travis/build-dist.sh
+++ b/travis/build-dist.sh
@@ -4,10 +4,10 @@
 
 set -e -x
 
-yum install -y atlas-devel
+ls /opt/python/
 
 # Compile wheels for each Python version
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp3*/bin; do
   "${PYBIN}/pip" install -r /io/requirements.txt
   "${PYBIN}/pip" install -e /io/
   cd /io
@@ -21,7 +21,7 @@ for whl in wheelhouse/anonlink-*.whl; do
 done
 
 # Install packages and test
-for PYBIN in /opt/python/*/bin; do
+for PYBIN in /opt/python/cp3*/bin; do
     "${PYBIN}/pip" install anonlink --no-index -f /io/wheelhouse
     (cd "$HOME"; "${PYBIN}/pytest" /io/tests -W ignore::DeprecationWarning)
 done

--- a/travis/build-dist.sh
+++ b/travis/build-dist.sh
@@ -8,8 +8,14 @@ yum install -y atlas-devel
 
 ls /opt/python/
 
+listOfPythons="
+cp35-cp35m
+cp36-cp36m
+cp37-cp37m"
+
 # Compile wheels for each Python version
-for PYBIN in /opt/python/cp3*/bin; do
+for pyPath in $listOfPythons; do
+  PYBIN="/opt/python/$pyPath/bin"
   "${PYBIN}/pip" install -r /io/requirements.txt
   "${PYBIN}/pip" install -e /io/
   cd /io
@@ -22,8 +28,9 @@ for whl in wheelhouse/anonlink-*.whl; do
     auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
 done
 
-# Install packages and test
-for PYBIN in /opt/python/cp3*/bin; do
+# Install packages and test for each Python version
+for pyPath in $listOfPythons; do
+    PYBIN="/opt/python/$pyPath/bin"
     "${PYBIN}/pip" install anonlink --no-index -f /io/wheelhouse
     (cd "$HOME"; "${PYBIN}/pytest" /io/tests -W ignore::DeprecationWarning)
 done


### PR DESCRIPTION
Travis was taking the easy route of just building wheels using Python 3.7 and to my surprise not everyone uses Python 3.7! This PR asks travis to kindly build and test with all/both supported Python versions available from the manylinux docker container calling the `build-dist.sh` script.

Closes #230 