### PR TITLE
Get azure to install and import the previously built wheel

### DIFF
--- a/.azurePipeline/python_init_package_install_steps.yml
+++ b/.azurePipeline/python_init_package_install_steps.yml
@@ -14,13 +14,18 @@ steps:
       pip install -r requirements.txt
   displayName: 'Install Python requirements'
 
-- script: python setup.py sdist bdist_wheel --universal
+- script: python setup.py sdist bdist_wheel
   env:
     CC: ${{ parameters.compiler }}
-  displayName: 'Package'
+  displayName: 'Build Package'
+
+- bash: |
+      pip install dist/anonlink*.whl
+      python -c "import anonlink; print(anonlink.__version__)"
+  displayName: 'Install anonlink wheel'
 
 - script: pip install -e .
-  displayName: 'Install anonlink'
+  displayName: 'Install anonlink for testing'
 
 - script: pytest --cov=anonlink --junitxml=testoutput.xml --cov-report=xml:coverage.xml --cov-report=html:htmlcov -W ignore::DeprecationWarning
   displayName: 'pytest'
@@ -41,8 +46,6 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: 'coverage.xml'
-# Seems to create warning as this step is already creating its own html pages.
-#      reportDirectory: 'htmlcov'
     failIfCoverageEmpty: true
 
 - bash: |


### PR DESCRIPTION
Adds a step to Azure Pipeline to try installing, importing and printing the version of `anonlink` from the previously built platform specific wheel.

Note the `--universal` was incorrect, so has been removed.

It is probably possible and would be very useful to run the pytest suite against the wheel - but it might not do coverage properly so thought I'd leave it out for now.