### PR TITLE
Build wheels for multiple platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ jobs:
         - travis_retry pip install -U mypy
       script:
         - mypy anonlink --ignore-missing-imports
-    - stage: Build wheels
+    - stage: "Build wheels"
+      name: "manylinux1_x86_64"
       sudo: required
       #if: tag IS present
       python: "3.6"
@@ -69,3 +70,20 @@ jobs:
       - ls wheelhouse/
       - python -m twine upload --skip-existing wheelhouse/anonlink*manylinux1_x86_64.whl
       - python -m twine upload --skip-existing wheelhouse/anonlink*.tar.gz
+    - name: "manylinux2010_x86_64"
+      sudo: required
+      if: tag IS present
+      python: "3.6"
+      services:
+      - docker
+      env:
+        - PLAT=manylinux2010_x86_64
+        - TWINE_USERNAME=confidentialcomputing
+      install:
+        - docker pull quay.io/pypa/manylinux1_x86_64
+        - travis_retry pip install -U twine
+      script:
+      - docker run --rm -e PLAT=$PLAT -v `pwd`:/io quay.io/pypa/manylinux2010_x86_64 /io/travis/build-dist.sh
+      - ls wheelhouse/
+      - python -m twine upload --skip-existing wheelhouse/anonlink*manylinux2010_x86_64.whl
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
     - stage: "Build wheels"
       name: "manylinux1_x86_64"
       sudo: required
-      #if: tag IS present
+      if: tag IS present
       python: "3.6"
       services:
       - docker
@@ -72,7 +72,7 @@ jobs:
       - python -m twine upload --skip-existing wheelhouse/anonlink*.tar.gz
     - name: "manylinux2010_x86_64"
       sudo: required
-      #if: tag IS present
+      if: tag IS present
       python: "3.6"
       services:
       - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ jobs:
       - python -m twine upload --skip-existing wheelhouse/anonlink*.tar.gz
     - name: "manylinux2010_x86_64"
       sudo: required
-      if: tag IS present
+      #if: tag IS present
       python: "3.6"
       services:
       - docker

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink",
-    version='0.12.5a1',
+    version='0.12.5a4',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This builds on PR #232 and adds support for the `manylinux2010` binary compatible wheel which succeeds `manylinux1` (https://www.python.org/dev/peps/pep-0571/)

Note this doesn't yet fully address #229 as I believe we also want to publish native wheels from OSX. Azure currently builds those but doesn't yet save the artifacts or push to PyPi.