### PR TITLE
Create wheels on Azure

### DIFF
--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -1,0 +1,12 @@
+
+steps:
+- task: UsePythonVersion@0
+- bash: |
+    # Use this fork of cibuildwheel for macos c++11 support
+    # https://github.com/joerick/cibuildwheel/pull/156
+    python -m pip install git+https://github.com/Czaki/cibuildwheel
+    cibuildwheel --output-dir wheelhouse .
+- bash: |
+    ls
+- task: PublishPipelineArtifact@1
+  inputs: {targetPath: 'wheelhouse'}

--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -6,7 +6,6 @@ steps:
     # https://github.com/joerick/cibuildwheel/pull/156
     python -m pip install git+https://github.com/Czaki/cibuildwheel
     cibuildwheel --output-dir wheelhouse .
-- bash: |
-    ls
+  displayName: Build Wheel
 - task: PublishPipelineArtifact@1
   inputs: {targetPath: 'wheelhouse'}

--- a/.azurePipeline/python_init_package_install_steps.yml
+++ b/.azurePipeline/python_init_package_install_steps.yml
@@ -19,11 +19,6 @@ steps:
     CC: ${{ parameters.compiler }}
   displayName: 'Build Package'
 
-- bash: |
-      pip install dist/anonlink*.whl
-      python -c "import anonlink; print(anonlink.__version__)"
-  displayName: 'Install anonlink wheel'
-
 - script: pip install -e .
   displayName: 'Install anonlink for testing'
 
@@ -56,11 +51,3 @@ steps:
       python -m codecov --token $(CODECOV_TOKEN) --file coverage.xml -F $opSysFlag,$pyVFlag,$compFlag
   displayName: 'Send coverage to codecov'
   condition: succeededOrFailed()
-
-# Note PipelineArtifacts replace BuildArtifacts
-- task: PublishPipelineArtifact@1
-  condition: and(eq(variables['compiler'], 'clang'), eq(variables['pythonVersion'], '3.7'))
-  displayName: 'Publish pipeline artifacts in Azure'
-  inputs:
-    targetPath: 'dist'
-    artifact: 'Build Artifacts ${{ parameters.operatingSystem }} for Python ${{ parameters.pythonVersion }}'

--- a/README.rst
+++ b/README.rst
@@ -24,29 +24,15 @@ from personally identifiable data.
 Installation
 ============
 
-Install directly from PyPi::
+Install a precompiled wheel from PyPi::
 
     pip install anonlink
 
-Or to install from source::
+Or (if your system has a C++ compiler) you can locally install from source::
 
     pip install -r requirements.txt
     pip install -e .
 
-Alternative - Manually compile the C++ library
-----------------------------------------------
-
-For mac with:
-
-::
-
-    g++ -std=c++11 -mssse3 -mpopcnt -O2 -Wall -pedantic -Wextra -dynamiclib -fpic -o _entitymatcher.dll dice_one_against_many.cpp
-
-For linux with:
-
-::
-
-    g++ -std=c++11 -mssse3 -mpopcnt -O2 -Wall -pedantic -Wextra -shared -fpic -o _entitymatcher.so dice_one_against_many.cpp
 
 Benchmark
 ---------

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -44,7 +44,6 @@ stages:
       - task: PublishPipelineArtifact@1
         inputs: {targetPath: 'wheelhouse'}
 
-
 - stage: build_and_test
   displayName: Unit tests
   dependsOn: []

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -31,7 +31,7 @@ stages:
           pip install cibuildwheel==0.11.1
           cibuildwheel --output-dir wheelhouse .
       - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse'}
+        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
   - job: linux_36
     displayName: Linux + Python3.6
     pool: {vmImage: 'Ubuntu-16.04'}
@@ -45,7 +45,7 @@ stages:
           pip install cibuildwheel==0.11.1
           cibuildwheel --output-dir wheelhouse .
       - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse'}
+        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
   - job: macos_37
     displayName: MacOS + Python3.7
     pool: {vmImage: 'macOS-10.13'}
@@ -55,10 +55,12 @@ stages:
     steps:
       - task: UsePythonVersion@0
       - bash: |
+          # Use this fork of cibuildwheel for macos c++11 support
+          # https://github.com/joerick/cibuildwheel/pull/156
           python -m pip install git+https://github.com/Czaki/cibuildwheel cython
           cibuildwheel --output-dir wheelhouse .
       - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse'}
+        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
 
   - job: macos_36
     displayName: MacOS + Python3.6
@@ -72,10 +74,10 @@ stages:
           python -m pip install git+https://github.com/Czaki/cibuildwheel cython
           cibuildwheel --output-dir wheelhouse .
       - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse'}
+        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
 
 - stage: build_and_test
-  displayName: Unit tests
+  displayName: Build and unit test
   dependsOn: []
   jobs:
   - job:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -13,32 +13,62 @@ stages:
   variables:
     CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
     CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml=testoutput.xml --cov-report=xml:coverage.xml --cov-report=html:htmlcov -W ignore::DeprecationWarning'
-    CIBW_BEFORE_BUILD: 'pip install -r requirements.txt && pip install -e .'
+    CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install wheel setuptools -r requirements.txt && pip install -e .'
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp37-* cp36-*'
     CIBW_SKIP: '*-win32 *-manylinux1_i686'
   jobs:
-  - job: linux
+  - job: linux_37
+    displayName: Linux + Python3.7
     pool: {vmImage: 'Ubuntu-16.04'}
     variables:
+      CIBW_BUILD: 'cp37-*'
       CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
     steps:
       - task: UsePythonVersion@0
       - bash: |
-          python -m pip install --upgrade pip
           python -m pip install --upgrade wheel setuptools
           pip install cibuildwheel==0.11.1
           cibuildwheel --output-dir wheelhouse .
       - task: PublishPipelineArtifact@1
         inputs: {targetPath: 'wheelhouse'}
-  - job: macos
+  - job: linux_36
+    displayName: Linux + Python3.6
+    pool: {vmImage: 'Ubuntu-16.04'}
+    variables:
+      CIBW_BUILD: 'cp36-*'
+      CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
+    steps:
+      - task: UsePythonVersion@0
+      - bash: |
+          python -m pip install --upgrade wheel setuptools
+          pip install cibuildwheel==0.11.1
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs: {targetPath: 'wheelhouse'}
+  - job: macos_37
+    displayName: MacOS + Python3.7
     pool: {vmImage: 'macOS-10.13'}
     variables:
+      CIBW_BUILD: 'cp37-*'
       CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
     steps:
       - task: UsePythonVersion@0
       - bash: |
-          python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/Czaki/cibuildwheel cython
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs: {targetPath: 'wheelhouse'}
+
+  - job: macos_36
+    displayName: MacOS + Python3.6
+    pool: {vmImage: 'macOS-10.13'}
+    variables:
+      CIBW_BUILD: 'cp36-*'
+      CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
+    steps:
+      - task: UsePythonVersion@0
+      - bash: |
           python -m pip install git+https://github.com/Czaki/cibuildwheel cython
           cibuildwheel --output-dir wheelhouse .
       - task: PublishPipelineArtifact@1

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -12,8 +12,10 @@ stages:
   displayName: Build Wheel Packages
   variables:
     CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
-    CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml=testoutput.xml --cov-report=xml:coverage.xml --cov-report=html:htmlcov -W ignore::DeprecationWarning'
+    CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k test_similarity_dice -W ignore::DeprecationWarning'
     CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install wheel setuptools -r requirements.txt && pip install -e .'
+    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
+    CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp37-* cp36-*'
     CIBW_SKIP: '*-win32 *-manylinux1_i686'
@@ -23,58 +25,35 @@ stages:
     pool: {vmImage: 'Ubuntu-16.04'}
     variables:
       CIBW_BUILD: 'cp37-*'
-      CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
     steps:
-      - task: UsePythonVersion@0
-      - bash: |
-          python -m pip install --upgrade wheel setuptools
-          pip install cibuildwheel==0.11.1
-          cibuildwheel --output-dir wheelhouse .
-      - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
+    - template: .azurePipeline/cibuildwheel_steps.yml
   - job: linux_36
     displayName: Linux + Python3.6
     pool: {vmImage: 'Ubuntu-16.04'}
     variables:
       CIBW_BUILD: 'cp36-*'
-      CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
     steps:
-      - task: UsePythonVersion@0
-      - bash: |
-          python -m pip install --upgrade wheel setuptools
-          pip install cibuildwheel==0.11.1
-          cibuildwheel --output-dir wheelhouse .
-      - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
+    - template: .azurePipeline/cibuildwheel_steps.yml
+
+#- stage: buildMacOSWheels
+#  displayName: Build macos Wheel Packages
+
   - job: macos_37
     displayName: MacOS + Python3.7
     pool: {vmImage: 'macOS-10.13'}
     variables:
       CIBW_BUILD: 'cp37-*'
-      CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
     steps:
-      - task: UsePythonVersion@0
-      - bash: |
-          # Use this fork of cibuildwheel for macos c++11 support
-          # https://github.com/joerick/cibuildwheel/pull/156
-          python -m pip install git+https://github.com/Czaki/cibuildwheel cython
-          cibuildwheel --output-dir wheelhouse .
-      - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
+    - template: .azurePipeline/cibuildwheel_steps.yml
 
   - job: macos_36
     displayName: MacOS + Python3.6
     pool: {vmImage: 'macOS-10.13'}
     variables:
       CIBW_BUILD: 'cp36-*'
-      CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
     steps:
-      - task: UsePythonVersion@0
-      - bash: |
-          python -m pip install git+https://github.com/Czaki/cibuildwheel cython
-          cibuildwheel --output-dir wheelhouse .
-      - task: PublishPipelineArtifact@1
-        inputs: {targetPath: 'wheelhouse', artifact: 'wheels'}
+    - template: .azurePipeline/cibuildwheel_steps.yml
+
 
 - stage: build_and_test
   displayName: Build and unit test

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -13,7 +13,7 @@ stages:
   variables:
     CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
     CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k test_similarity_dice -W ignore::DeprecationWarning'
-    CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -r requirements.txt && pip install -e .'
+    CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -e .'
     # Need to install development libraries for manylinux container
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel && pip install -e . && python setup.py build'
 

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -12,7 +12,7 @@ stages:
   displayName: Build Wheel Packages
   variables:
     CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
-    CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k test_similarity_dice -W ignore::DeprecationWarning'
+    CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k "test_similarity_dice or test_solving" -W ignore::DeprecationWarning'
     CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -e .'
     # Need to install development libraries for manylinux container
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel && pip install -e .'

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -6,9 +6,47 @@ trigger:
     include:
     - '*'
 
+
 stages:
+- stage: buildWheels
+  displayName: Build Wheel Packages
+  variables:
+    CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
+    CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml=testoutput.xml --cov-report=xml:coverage.xml --cov-report=html:htmlcov -W ignore::DeprecationWarning'
+    CIBW_BEFORE_BUILD: 'pip install -r requirements.txt && pip install -e .'
+    # Only build for Python36+, and x64 arch
+    CIBW_BUILD: 'cp37-* cp36-*'
+    CIBW_SKIP: '*-win32 *-manylinux1_i686'
+  jobs:
+  - job: linux
+    pool: {vmImage: 'Ubuntu-16.04'}
+    variables:
+      CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
+    steps:
+      - task: UsePythonVersion@0
+      - bash: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel setuptools
+          pip install cibuildwheel==0.11.1
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs: {targetPath: 'wheelhouse'}
+  - job: macos
+    pool: {vmImage: 'macOS-10.13'}
+    variables:
+      CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
+    steps:
+      - task: UsePythonVersion@0
+      - bash: |
+          python -m pip install --upgrade pip
+          python -m pip install git+https://github.com/Czaki/cibuildwheel cython
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishPipelineArtifact@1
+        inputs: {targetPath: 'wheelhouse'}
+
+
 - stage: build_and_test
-  displayName: Build and test
+  displayName: Unit tests
   dependsOn: []
   jobs:
   - job:
@@ -43,7 +81,6 @@ stages:
         compiler: $(compiler)
         pythonVersion: $(pythonVersion)
         operatingSystem: 'ubuntu-16.04'
-
 
   - job:
     displayName: OSX

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -15,7 +15,7 @@ stages:
     CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k test_similarity_dice -W ignore::DeprecationWarning'
     CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -e .'
     # Need to install development libraries for manylinux container
-    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel && pip install -e . && python setup.py build'
+    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel && pip install -e .'
 
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp37-* cp36-*'

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -13,9 +13,9 @@ stages:
   variables:
     CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
     CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k test_similarity_dice -W ignore::DeprecationWarning'
-    CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install wheel setuptools -r requirements.txt && pip install -e .'
+    CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -r requirements.txt && pip install -e .'
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
-    CIBW_ENVIRONMENT_MACOS: 'CC="clang" CXXFLAGS="-stdlib=libc++ -mssse3 -mpopcnt"'
+
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp37-* cp36-*'
     CIBW_SKIP: '*-win32 *-manylinux1_i686'
@@ -34,9 +34,6 @@ stages:
       CIBW_BUILD: 'cp36-*'
     steps:
     - template: .azurePipeline/cibuildwheel_steps.yml
-
-#- stage: buildMacOSWheels
-#  displayName: Build macos Wheel Packages
 
   - job: macos_37
     displayName: MacOS + Python3.7

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -14,7 +14,8 @@ stages:
     CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
     CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k test_similarity_dice -W ignore::DeprecationWarning'
     CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -r requirements.txt && pip install -e .'
-    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-dev atlas-devel && pip install -e . && python setup.py build'
+    # Need to install development libraries for manylinux container
+    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel && pip install -e . && python setup.py build'
 
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp37-* cp36-*'


### PR DESCRIPTION
This PR uses a plugin [`cibuildwheel`](https://github.com/joerick/cibuildwheel) to build the binary wheels for manylinux and macos on Azure DevOps. The main contribution is our manylinux wheel hasn't been built with azure until now.

Note I kept all of the old pipeline for building and unit testing as it submits coverage and displays the test results in Azure. The new way uses docker compose on linux to build the manylinux wheel and it doesn't seem easy to directly upload the coverage or test results from within the container.

A couple of follow on changes would be good:
- The *unit test* job could depend on and use the wheels built in the newly added stage - or the coverage & test results from the wheel testing could be exported.
- A release pipeline should be created to publish the wheels to pypi on tagged commits.