### PR TITLE
fix for #239

### DIFF
--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -62,7 +62,6 @@ def test_similarities_hist(candidate_pairs, bins):
         candidate_pairs, bins=bins)
 
     assert sorted(bin_edges) == list(bin_edges)
-    assert len(set(bin_edges)) == len(bin_edges) == bins + 1
     assert len(counts) == bins
 
     for count, bin_edge_left, bin_edge_right in zip(


### PR DESCRIPTION
The problem is that if the difference between the similarity scores is tiny but there are a lot of bins in the histogram, then, because of floating point imprecision, the elements in 'bin_edges' are not necessarily unique.

fixes #239