### PR TITLE
Add support for other platforms with libpopcnt

### DIFF
--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -4,8 +4,12 @@ steps:
 - bash: |
     # Use this fork of cibuildwheel for macos c++11 support
     # https://github.com/joerick/cibuildwheel/pull/156
-    python -m pip install git+https://github.com/Czaki/cibuildwheel
+    # python -m pip install git+https://github.com/Czaki/cibuildwheel
+    python -m pip install cibuildwheel==0.12.0
+    cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
   displayName: Build Wheel
+- task: PublishBuildArtifacts@1
+  inputs: {pathtoPublish: 'wheelhouse'}
 - task: PublishPipelineArtifact@1
   inputs: {targetPath: 'wheelhouse'}

--- a/.azurePipeline/unittest_wheel_steps.yml
+++ b/.azurePipeline/unittest_wheel_steps.yml
@@ -30,16 +30,7 @@ steps:
     rm -fr anonlink
     pytest --cov=anonlink --junitxml=$(Common.TestResultsDirectory)/testoutput.xml --cov-report=xml:$(Common.TestResultsDirectory)/coverage.xml -W ignore::DeprecationWarning
   displayName: 'pytest'
-  
-#- task: PublishTestResults@2
-#  displayName: 'Publish test results in Azure'
-#  condition: succeededOrFailed()
-#  inputs:
-#    testResultsFormat: 'JUnit'
-#    testResultsFiles: '$(Common.TestResultsDirectory)/testoutput.xml'
-#    testRunTitle: 'Test results on a vm ${{ parameters.operatingSystem }} for Python ${{ parameters.pythonVersion }}'
-#    failTaskOnFailedTests: true
-#
+
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage in Azure'
   # If the previous stage fail, we still want to run this one as the previous stage may fail because of a failing test.
@@ -47,7 +38,7 @@ steps:
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(Common.TestResultsDirectory)/coverage.xml'
-    failIfCoverageEmpty: true
+    failIfCoverageEmpty: false
 
 - bash: |
       opSysFlag=$(echo ${{ parameters.operatingSystem }} | sed 's/[[:punct:]]//g' | tr '[:upper:]' '[:lower:]' | head -c30)

--- a/.azurePipeline/unittest_wheel_steps.yml
+++ b/.azurePipeline/unittest_wheel_steps.yml
@@ -26,26 +26,29 @@ steps:
   displayName: 'Install anonlink wheel'
 
 - script: |
+    # Delete the source code folder to ensure we test the installed wheel
+    rm -fr anonlink
+    #cd tests
     pytest --cov=anonlink --junitxml=$(Common.TestResultsDirectory)/testoutput.xml --cov-report=xml:$(Common.TestResultsDirectory)/coverage.xml -W ignore::DeprecationWarning
   displayName: 'pytest'
   
-- task: PublishTestResults@2
-  displayName: 'Publish test results in Azure'
-  condition: succeededOrFailed()
-  inputs:
-    testResultsFormat: 'JUnit'
-    testResultsFiles: '$(Common.TestResultsDirectory)/testoutput.xml'
-    testRunTitle: 'Test results on a vm ${{ parameters.operatingSystem }} for Python ${{ parameters.pythonVersion }}'
-    failTaskOnFailedTests: true
-
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish code coverage in Azure'
-  # If the previous stage fail, we still want to run this one as the previous stage may fail because of a failing test.
-  condition: succeededOrFailed()
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Common.TestResultsDirectory)/coverage.xml'
-    failIfCoverageEmpty: true
+#- task: PublishTestResults@2
+#  displayName: 'Publish test results in Azure'
+#  condition: succeededOrFailed()
+#  inputs:
+#    testResultsFormat: 'JUnit'
+#    testResultsFiles: '$(Common.TestResultsDirectory)/testoutput.xml'
+#    testRunTitle: 'Test results on a vm ${{ parameters.operatingSystem }} for Python ${{ parameters.pythonVersion }}'
+#    failTaskOnFailedTests: true
+#
+#- task: PublishCodeCoverageResults@1
+#  displayName: 'Publish code coverage in Azure'
+#  # If the previous stage fail, we still want to run this one as the previous stage may fail because of a failing test.
+#  condition: succeededOrFailed()
+#  inputs:
+#    codeCoverageTool: Cobertura
+#    summaryFileLocation: '$(Common.TestResultsDirectory)/coverage.xml'
+#    failIfCoverageEmpty: true
 
 - bash: |
       opSysFlag=$(echo ${{ parameters.operatingSystem }} | sed 's/[[:punct:]]//g' | tr '[:upper:]' '[:lower:]' | head -c30)

--- a/.azurePipeline/unittest_wheel_steps.yml
+++ b/.azurePipeline/unittest_wheel_steps.yml
@@ -28,24 +28,15 @@ steps:
 - script: |
     # Delete the source code folder to ensure we test only the installed wheel
     rm -fr anonlink
-    pytest --cov=anonlink --junitxml=$(Common.TestResultsDirectory)/testoutput.xml --cov-report=xml:$(Common.TestResultsDirectory)/coverage.xml -W ignore::DeprecationWarning
+    pytest --cov=anonlink --junitxml=$(Common.TestResultsDirectory)/testoutput.xml --cov-report=xml:coverage.xml --cov-report html -W ignore::DeprecationWarning
   displayName: 'pytest'
-
-- task: PublishCodeCoverageResults@1
-  displayName: 'Publish code coverage in Azure'
-  # If the previous stage fail, we still want to run this one as the previous stage may fail because of a failing test.
-  condition: succeededOrFailed()
-  inputs:
-    codeCoverageTool: Cobertura
-    summaryFileLocation: '$(Common.TestResultsDirectory)/coverage.xml'
-    failIfCoverageEmpty: false
 
 - bash: |
       opSysFlag=$(echo ${{ parameters.operatingSystem }} | sed 's/[[:punct:]]//g' | tr '[:upper:]' '[:lower:]' | head -c30)
       pyVFlag=$(echo python${{ parameters.pythonVersion }} | sed 's/[[:punct:]]//g' | tr '[:upper:]' '[:lower:]' | head -c30)
-      echo "python -m codecov --file coverage.xml -F $opSysFlag,$pyVFlag"
+      echo "codecov flags: $opSysFlag,$pyVFlag"
       python -m codecov --token $(CODECOV_TOKEN) \
-        --file $(Common.TestResultsDirectory)/coverage.xml \
+        --file coverage.xml \
         -F $opSysFlag,$pyVFlag
   displayName: 'Send coverage to codecov'
   condition: succeededOrFailed()

--- a/.azurePipeline/unittest_wheel_steps.yml
+++ b/.azurePipeline/unittest_wheel_steps.yml
@@ -2,6 +2,7 @@ parameters:
   pythonVersion: '3.7'
   operatingSystem: 'ubuntu-16.04'
   artifactName: 'wheels.linux37'
+  artifactPattern: '**/*.whl'
 
 steps:
 - task: UsePythonVersion@0
@@ -10,18 +11,19 @@ steps:
   displayName: 'Init Python'
 
 - script: |
-      pip install -U codecov -r requirements.txt
+      python -m pip install --upgrade pip
+      pip install -U pytest-azurepipelines codecov -r requirements.txt
   displayName: 'Install testing requirements'
 
 - task: DownloadPipelineArtifact@2
   inputs:
     artifactName: ${{ parameters.artifactName }}
-    patterns: '**/*.whl'
+    patterns: ${{ parameters.artifactPattern }}
     path: $(Pipeline.Workspace)
 
 - script: |
-      pip install $(Pipeline.Workspace)/anonlink*.whl
-  displayName: 'Install anonlink'
+      pip install anonlink --no-index -f $(Pipeline.Workspace)
+  displayName: 'Install anonlink wheel'
 
 - script: |
     # Delete the source code folder to ensure we test the installed wheel

--- a/.azurePipeline/unittest_wheel_steps.yml
+++ b/.azurePipeline/unittest_wheel_steps.yml
@@ -26,9 +26,8 @@ steps:
   displayName: 'Install anonlink wheel'
 
 - script: |
-    # Delete the source code folder to ensure we test the installed wheel
+    # Delete the source code folder to ensure we test only the installed wheel
     rm -fr anonlink
-    #cd tests
     pytest --cov=anonlink --junitxml=$(Common.TestResultsDirectory)/testoutput.xml --cov-report=xml:$(Common.TestResultsDirectory)/coverage.xml -W ignore::DeprecationWarning
   displayName: 'pytest'
   
@@ -41,14 +40,14 @@ steps:
 #    testRunTitle: 'Test results on a vm ${{ parameters.operatingSystem }} for Python ${{ parameters.pythonVersion }}'
 #    failTaskOnFailedTests: true
 #
-#- task: PublishCodeCoverageResults@1
-#  displayName: 'Publish code coverage in Azure'
-#  # If the previous stage fail, we still want to run this one as the previous stage may fail because of a failing test.
-#  condition: succeededOrFailed()
-#  inputs:
-#    codeCoverageTool: Cobertura
-#    summaryFileLocation: '$(Common.TestResultsDirectory)/coverage.xml'
-#    failIfCoverageEmpty: true
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish code coverage in Azure'
+  # If the previous stage fail, we still want to run this one as the previous stage may fail because of a failing test.
+  condition: succeededOrFailed()
+  inputs:
+    codeCoverageTool: Cobertura
+    summaryFileLocation: '$(Common.TestResultsDirectory)/coverage.xml'
+    failIfCoverageEmpty: true
 
 - bash: |
       opSysFlag=$(echo ${{ parameters.operatingSystem }} | sed 's/[[:punct:]]//g' | tr '[:upper:]' '[:lower:]' | head -c30)

--- a/.azurePipeline/unittest_wheel_steps.yml
+++ b/.azurePipeline/unittest_wheel_steps.yml
@@ -26,9 +26,6 @@ steps:
   displayName: 'Install anonlink wheel'
 
 - script: |
-    # Delete the source code folder to ensure we test the installed wheel
-    rm -fr anonlink
-    cd tests
     pytest --cov=anonlink --junitxml=$(Common.TestResultsDirectory)/testoutput.xml --cov-report=xml:$(Common.TestResultsDirectory)/coverage.xml -W ignore::DeprecationWarning
   displayName: 'pytest'
   

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+0.13.0-dev
+==========
+
+- Adds support for Windows including accelerated extensions. Note performance on Windows is
+  roughly half that of Linux.
+
 0.12.5
 ======
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,3 +11,4 @@ exclude .jenkins
 global-include *.pyx
 global-include *.pxd
 include anonlink/solving/_multiparty_solving_inner.h
+include _cffi_build/libpopcount.h

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,10 +3,6 @@ recursive-include _cffi_build *
 # Remove CFFI files
 global-exclude __pycache__/*
 
-# Exclude jenkins things
-exclude Jenkinsfile
-exclude .jenkins
-
 # Include Cython code
 global-include *.pyx
 global-include *.pxd

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ global-include *.pyx
 global-include *.pxd
 include anonlink/solving/_multiparty_solving_inner.h
 include _cffi_build/libpopcount.h
+include anonlink/_entitymatcher*

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,8 @@
 
+.. image:: https://dev.azure.com/data61/Anonlink/_apis/build/status/data61.anonlink?branchName=master
+    :target: https://dev.azure.com/data61/Anonlink/_build/latest?definitionId=3&branchName=master
+
+
 .. image:: https://travis-ci.org/data61/anonlink.svg?branch=master
     :target: https://travis-ci.org/data61/anonlink
 

--- a/_cffi_build/build_matcher.py
+++ b/_cffi_build/build_matcher.py
@@ -12,10 +12,9 @@ with open(sourcefile, 'r') as f:
 
 current_os = platform.system()
 if current_os == "Windows":
-    extra_compile_args = ['-Wall', '/std:c++17', '/arch:AVX512']
+    extra_compile_args = ['-Wall', '/std:c++17', '/O2', '/arch:AVX512']
 else:
-    extra_compile_args = ['-Wall', '-Wextra', '-Werror', '-O3', '-std=c++11', '-march=native', '-mssse3', '-mpopcnt',
-                          '-fvisibility=hidden']
+    extra_compile_args = ['-Wall', '-Wextra', '-Werror', '-O3', '-std=c++11', '-fvisibility=hidden']
 
 
 ffibuilder.set_source(

--- a/_cffi_build/build_matcher.py
+++ b/_cffi_build/build_matcher.py
@@ -1,5 +1,5 @@
 import os.path
-
+import platform
 from cffi import FFI
 
 ffibuilder = FFI()
@@ -10,13 +10,19 @@ sourcefile = os.path.join(_path, 'dice_one_against_many.cpp')
 with open(sourcefile, 'r') as f:
     source = f.read()
 
+current_os = platform.system()
+if current_os == "Windows":
+    extra_compile_args = ['-Wall', '/std:c++17', '/arch:AVX512']
+else:
+    extra_compile_args = ['-Wall', '-Wextra', '-Werror', '-O3', '-std=c++11', '-march=native', '-mssse3', '-mpopcnt',
+                          '-fvisibility=hidden']
+
 
 ffibuilder.set_source(
     "_entitymatcher",
     source,
     source_extension='.cpp',
-    extra_compile_args=['-Wall', '-Wextra', '-Werror', '-O3', '-std=c++11', '-march=native', '-mssse3', '-mpopcnt', '-fvisibility=hidden'
-    ],
+    extra_compile_args=extra_compile_args
 )
 
 ffibuilder.cdef("""

--- a/_cffi_build/build_matcher.py
+++ b/_cffi_build/build_matcher.py
@@ -22,13 +22,15 @@ ffibuilder.set_source(
     "_entitymatcher",
     source,
     source_extension='.cpp',
-    extra_compile_args=extra_compile_args
+    extra_compile_args=extra_compile_args,
+    include_dirs=[_path]
 )
 
 ffibuilder.cdef("""
     int match_one_against_many_dice_k_top(const char *one, const char *many, const uint32_t *counts_many, int n, int keybytes, uint32_t k, double threshold, int *indices, double *scores);
     double dice_coeff(const char *array1, const char *array2, int array_bytes);
     double popcount_arrays(uint32_t *counts, const char *arrays, int narrays, int array_bytes);
+    uint64_t popcnt(const void* data, uint64_t size);
 """)
 
 

--- a/_cffi_build/build_matcher.py
+++ b/_cffi_build/build_matcher.py
@@ -12,7 +12,7 @@ with open(sourcefile, 'r') as f:
 
 current_os = platform.system()
 if current_os == "Windows":
-    extra_compile_args = ['-Wall', '/std:c++17', '/O2', '/arch:AVX512']
+    extra_compile_args = ['-Wall', '/std:c++17', '/O2']         # '/arch:AVX512' or '/arch:AVX2'
 else:
     extra_compile_args = ['-Wall', '-Wextra', '-Werror', '-O3', '-std=c++11', '-fvisibility=hidden']
 

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -24,10 +24,9 @@ static constexpr int WORD_BYTES = sizeof(uint64_t);
 template<int n>
 static inline void
 popcount(
-        uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
+        uint64_t &c0, uint64_t &, uint64_t &, uint64_t &,
         const uint64_t *buf) {
-    popcount<4>(c0, c1, c2, c3, buf);
-    popcount<n - 4>(c0, c1, c2, c3, buf + 4);
+    c0 += popcnt(buf, n*WORD_BYTES);
 }
 
 
@@ -37,12 +36,9 @@ popcount(
 template<>
 inline void
 popcount<4>(
-        uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
+        uint64_t &c0, uint64_t &, uint64_t &, uint64_t &,
         const uint64_t *buf) {
         c0 += popcnt(buf, 4*WORD_BYTES);
-        c1 += 0;
-        c2 += 0;
-        c3 += 0;
 }
 
 // Slow paths
@@ -64,15 +60,14 @@ popcount<3>(
 #endif
 
 /**
- * The popcount of 2 elements of buf is the sum of c0, c1.
+ * The popcount of 2 elements of buf is the sum of c0.
  */
 template<>
 inline void
 popcount<2>(
-        uint64_t &c0, uint64_t &c1, uint64_t &, uint64_t &,
+        uint64_t &c0, uint64_t &, uint64_t &, uint64_t &,
         const uint64_t *buf) {
-    c0 += __builtin_popcountl(buf[0]);
-    c1 += __builtin_popcountl(buf[1]);
+    c0 += popcnt(buf, 2*WORD_BYTES);
 }
 
 /**
@@ -134,14 +129,14 @@ popcount_logand(
 template<>
 inline void
 popcount_logand<4>(
-        uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
+        uint64_t &c0, uint64_t &, uint64_t &, uint64_t &,
         const uint64_t *buf1, const uint64_t *buf2) {
     uint64_t b[4];
     b[0] = buf1[0] & buf2[0];
     b[1] = buf1[1] & buf2[1];
     b[2] = buf1[2] & buf2[2];
     b[3] = buf1[3] & buf2[3];
-    popcount<4>(c0, c1, c2, c3, b);
+    c0 += popcnt(b, 4*WORD_BYTES);
 }
 
 /**

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -144,8 +144,6 @@ _popcount_arrays(uint32_t *counts, const uint64_t *arrays, int narrays) {
  */
 static uint32_t
 _popcount_array(const uint64_t *array, int nwords) {
-    //return popcnt(array, nwords*WORD_BYTES);
-
     uint64_t c0, c1, c2, c3;
     c0 = c1 = c2 = c3 = 0;
     while (nwords >= 16) {
@@ -186,11 +184,33 @@ static inline void
 popcount_logand(
         uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
         const uint64_t *buf1, const uint64_t *buf2) {
+#if defined (_MSC_VER)
     uint64_t b[n];
     for (int i = 0; i < n; i++) {
         b[i] = buf1[i] & buf2[i];
     }
     popcount<n>(c0, c1, c2, c3, b);
+#else
+    popcount_logand<4>(c0, c1, c2, c3, buf1, buf2);
+    popcount_logand<n - 4>(c0, c1, c2, c3, buf1 + 4, buf2 + 4);
+#endif
+}
+
+/**
+ * The popcount of the logical AND of 4 corresponding elements of buf1
+ * and buf2 is the sum of c0, c1, c2, c3.
+ */
+template<>
+inline void
+popcount_logand<4>(
+        uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
+        const uint64_t *buf1, const uint64_t *buf2) {
+    uint64_t b[4];
+    b[0] = buf1[0] & buf2[0];
+    b[1] = buf1[1] & buf2[1];
+    b[2] = buf1[2] & buf2[2];
+    b[3] = buf1[3] & buf2[3];
+    popcount<4>(c0, c1, c2, c3, b);
 }
 
 /**

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -51,8 +51,10 @@ inline void
 popcount<4>(
         uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
         const uint64_t *buf) {
-        c0 = popcnt(buf, 4);
-        c1 = 0; c2 = 0; c3 = 0;
+        c0 += popcnt(buf, 4*8);
+        c1 += 0;
+        c2 += 0;
+        c3 += 0;
 }
 
 // Slow paths
@@ -111,11 +113,12 @@ popcount<1>(
 template<int nwords>
 static void
 _popcount_arrays(uint32_t *counts, const uint64_t *arrays, int narrays) {
-    uint64_t c0, c1, c2, c3;
+    //uint64_t c0, c1, c2, c3;
     for (int i = 0; i < narrays; ++i, arrays += nwords) {
-        c0 = c1 = c2 = c3 = 0;
-        popcount<nwords>(c0, c1, c2, c3, arrays);
-        counts[i] = c0 + c1 + c2 + c3;
+        //c0 = c1 = c2 = c3 = 0;
+        //popcount<nwords>(c0, c1, c2, c3, arrays);
+        //counts[i] = c0 + c1 + c2 + c3;
+        counts[i] = popcnt(arrays, nwords*8);
     }
 }
 
@@ -124,36 +127,8 @@ _popcount_arrays(uint32_t *counts, const uint64_t *arrays, int narrays) {
  */
 static uint32_t
 _popcount_array(const uint64_t *array, int nwords) {
-    uint64_t c0, c1, c2, c3;
-    c0 = c1 = c2 = c3 = 0;
-
-    while (nwords >= 16) {
-        popcount<16>(c0, c1, c2, c3, array);
-        array += 16;
-        nwords -= 16;
-    }
-    // nwords < 16
-    if (nwords >= 8) {
-        popcount<8>(c0, c1, c2, c3, array);
-        array += 8;
-        nwords -= 8;
-    }
-    // nwords < 8
-    if (nwords >= 4) {
-        popcount<4>(c0, c1, c2, c3, array);
-        array += 4;
-        nwords -= 4;
-    }
-    // nwords < 4
-    if (nwords >= 2) {
-        popcount<2>(c0, c1, c2, c3, array);
-        array += 2;
-        nwords -= 2;
-    }
-    // nwords < 2
-    if (nwords == 1)
-        popcount<1>(c0, c1, c2, c3, array);
-    return c0 + c1 + c2 + c3;
+    int wordsize_in_bytes = sizeof(void*);
+    return popcnt(array, nwords*wordsize_in_bytes);
 }
 
 /**

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -10,31 +10,25 @@
 #include <climits>
 #include "libpopcount.h"
 
-#if defined (_MSC_VER)
-// code specific to Visual Studio compiler
-# include <intrin.h>
-# define __builtin_popcountl __popcnt64
-#endif
-
 static constexpr int WORD_BYTES = sizeof(uint64_t);
 
 /**
- * The popcount of n elements of buf is the sum of c0, c1, c2, c3.
+ * Popcount of n elements of buf.
  */
 template<int n>
 static inline void
-popcount(
-        uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
-        const uint64_t *buf) {
 #if defined (_MSC_VER)
+// code specific to Visual Studio compiler
+// With MSVC we call libpopcnt with the whole data and return the popcount in c0
+popcount( uint64_t &c0, uint64_t &, uint64_t &, uint64_t &, const uint64_t *buf) {
     c0 += popcnt(buf, n*WORD_BYTES);
-    c1 += 0; c2 += 0; c3 += 0;
 #else
+// The popcount of n elements of buf is the sum of c0, c1, c2, c3.
+popcount( uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3, const uint64_t *buf) {
     popcount<4>(c0, c1, c2, c3, buf);
     popcount<n - 4>(c0, c1, c2, c3, buf + 4);
 #endif
 }
-
 
 /**
  * The popcount of 4 elements of buf is the sum of c0, c1, c2, c3.
@@ -252,9 +246,9 @@ _popcount_logand_array(const uint64_t *u, const uint64_t *v, int len) {
     // Clang not to complain about the fact that the case clauses
     // don't have break statements in them.
     switch (nwords) {
-    case 3: c2 += __builtin_popcountl(u[2] & v[2]);  /* fall through */
-    case 2: c1 += __builtin_popcountl(u[1] & v[1]);  /* fall through */
-    case 1: c0 += __builtin_popcountl(u[0] & v[0]);  /* fall through */
+    case 3: c2 += popcnt64(u[2] & v[2]);  /* fall through */
+    case 2: c1 += popcnt64(u[1] & v[1]);  /* fall through */
+    case 1: c0 += popcnt64(u[0] & v[0]);  /* fall through */
     }
 
     return c0 + c1 + c2 + c3;

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -8,6 +8,13 @@
 #include <ctime>
 #include <cassert>
 #include <climits>
+#include "libpopcount.h"
+
+#if defined (_MSC_VER)
+// code specific to Visual Studio compiler
+# include <intrin.h>
+# define __builtin_popcountl __popcnt64
+#endif
 
 static constexpr int WORD_BYTES = sizeof(uint64_t);
 
@@ -44,19 +51,8 @@ inline void
 popcount<4>(
         uint64_t &c0, uint64_t &c1, uint64_t &c2, uint64_t &c3,
         const uint64_t *buf) {
-    uint64_t b0, b1, b2, b3;
-    b0 = buf[0]; b1 = buf[1]; b2 = buf[2]; b3 = buf[3];
-    __asm__(
-        "popcnt %4, %4  \n\t"
-        "add %4, %0     \n\t"
-        "popcnt %5, %5  \n\t"
-        "add %5, %1     \n\t"
-        "popcnt %6, %6  \n\t"
-        "add %6, %2     \n\t"
-        "popcnt %7, %7  \n\t"
-        "add %7, %3     \n\t"
-        : "+r" (c0), "+r" (c1), "+r" (c2), "+r" (c3),
-          "+r" (b0), "+r" (b1), "+r" (b2), "+r" (b3));
+        c0 = popcnt(buf, 4);
+        c1 = 0; c2 = 0; c3 = 0;
 }
 
 // Slow paths

--- a/_cffi_build/dice_one_against_many.cpp
+++ b/_cffi_build/dice_one_against_many.cpp
@@ -133,8 +133,6 @@ static void
 _popcount_arrays(uint32_t *counts, const uint64_t *arrays, int narrays) {
     uint64_t c0, c1, c2, c3;
     for (int i = 0; i < narrays; ++i, arrays += nwords) {
-        // TODO maybe just on Windows for performance
-        //counts[i] = popcnt(arrays, nwords*WORD_BYTES);
         c0 = c1 = c2 = c3 = 0;
         popcount<nwords>(c0, c1, c2, c3, arrays);
         counts[i] = c0 + c1 + c2 + c3;
@@ -150,7 +148,6 @@ _popcount_array(const uint64_t *array, int nwords) {
 
     uint64_t c0, c1, c2, c3;
     c0 = c1 = c2 = c3 = 0;
-
     while (nwords >= 16) {
         popcount<16>(c0, c1, c2, c3, array);
         array += 16;
@@ -208,7 +205,7 @@ _popcount_logand_array(const uint64_t *u, const uint64_t *v, int len) {
     uint64_t c0, c1, c2, c3;
     c0 = c1 = c2 = c3 = 0;
     int nwords = len;
-
+#if defined (_MSC_VER)
     while (nwords >= 128) {
         popcount_logand<128>(c0, c1, c2, c3, u, v);
         u += 128;
@@ -222,6 +219,7 @@ _popcount_logand_array(const uint64_t *u, const uint64_t *v, int len) {
         v += 16;
         nwords -= 16;
     }
+#endif
     // 4 <= nwords < 128
     while (nwords >= 4) {
         popcount_logand<4>(c0, c1, c2, c3, u, v);

--- a/_cffi_build/libpopcount.h
+++ b/_cffi_build/libpopcount.h
@@ -1,0 +1,821 @@
+/*
+ * https://github.com/kimwalisch/libpopcnt
+ *
+ * libpopcnt.h - C/C++ library for counting the number of 1 bits (bit
+ * population count) in an array as quickly as possible using
+ * specialized CPU instructions i.e. POPCNT, AVX2, AVX512, NEON.
+ *
+ * Copyright (c) 2016 - 2018, Kim Walisch
+ * Copyright (c) 2016 - 2018, Wojciech Muła
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef LIBPOPCNT_H
+#define LIBPOPCNT_H
+
+#include <stdint.h>
+
+#ifndef __has_builtin
+  #define __has_builtin(x) 0
+#endif
+
+#ifndef __has_attribute
+  #define __has_attribute(x) 0
+#endif
+
+#ifdef __GNUC__
+  #define GNUC_PREREQ(x, y) \
+      (__GNUC__ > x || (__GNUC__ == x && __GNUC_MINOR__ >= y))
+#else
+  #define GNUC_PREREQ(x, y) 0
+#endif
+
+#ifdef __clang__
+  #define CLANG_PREREQ(x, y) \
+      (__clang_major__ > x || (__clang_major__ == x && __clang_minor__ >= y))
+#else
+  #define CLANG_PREREQ(x, y) 0
+#endif
+
+#if (_MSC_VER < 1900) && \
+    !defined(__cplusplus)
+  #define inline __inline
+#endif
+
+#if (defined(__i386__) || \
+     defined(__x86_64__) || \
+     defined(_M_IX86) || \
+     defined(_M_X64))
+  #define X86_OR_X64
+#endif
+
+#if defined(X86_OR_X64) && \
+   (defined(__cplusplus) || \
+    defined(_MSC_VER) || \
+   (GNUC_PREREQ(4, 2) || \
+    __has_builtin(__sync_val_compare_and_swap)))
+  #define HAVE_CPUID
+#endif
+
+#if GNUC_PREREQ(4, 2) || \
+    __has_builtin(__builtin_popcount)
+  #define HAVE_BUILTIN_POPCOUNT
+#endif
+
+#if GNUC_PREREQ(4, 2) || \
+    CLANG_PREREQ(3, 0)
+  #define HAVE_ASM_POPCNT
+#endif
+
+#if defined(HAVE_CPUID) && \
+   (defined(HAVE_ASM_POPCNT) || \
+    defined(_MSC_VER))
+  #define HAVE_POPCNT
+#endif
+
+#if defined(HAVE_CPUID) && \
+    GNUC_PREREQ(4, 9)
+  #define HAVE_AVX2
+#endif
+
+#if defined(HAVE_CPUID) && \
+    GNUC_PREREQ(5, 0)
+  #define HAVE_AVX512
+#endif
+
+#if defined(HAVE_CPUID) && \
+    defined(_MSC_VER) && \
+    defined(__AVX2__)
+  #define HAVE_AVX2
+#endif
+
+#if defined(HAVE_CPUID) && \
+    defined(_MSC_VER) && \
+    defined(__AVX512__)
+  #define HAVE_AVX512
+#endif
+
+#if defined(HAVE_CPUID) && \
+    CLANG_PREREQ(3, 8) && \
+    __has_attribute(target) && \
+   (!defined(_MSC_VER) || defined(__AVX2__)) && \
+   (!defined(__apple_build_version__) || __apple_build_version__ >= 8000000)
+  #define HAVE_AVX2
+  #define HAVE_AVX512
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * This uses fewer arithmetic operations than any other known
+ * implementation on machines with fast multiplication.
+ * It uses 12 arithmetic operations, one of which is a multiply.
+ * http://en.wikipedia.org/wiki/Hamming_weight#Efficient_implementation
+ */
+static inline uint64_t popcount64(uint64_t x)
+{
+  uint64_t m1 = 0x5555555555555555ll;
+  uint64_t m2 = 0x3333333333333333ll;
+  uint64_t m4 = 0x0F0F0F0F0F0F0F0Fll;
+  uint64_t h01 = 0x0101010101010101ll;
+
+  x -= (x >> 1) & m1;
+  x = (x & m2) + ((x >> 2) & m2);
+  x = (x + (x >> 4)) & m4;
+
+  return (x * h01) >> 56;
+}
+
+#if defined(HAVE_ASM_POPCNT) && \
+    defined(__x86_64__)
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  __asm__ ("popcnt %1, %0" : "=r" (x) : "0" (x));
+  return x;
+}
+
+#elif defined(HAVE_ASM_POPCNT) && \
+      defined(__i386__)
+
+static inline uint32_t popcnt32(uint32_t x)
+{
+  __asm__ ("popcnt %1, %0" : "=r" (x) : "0" (x));
+  return x;
+}
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  return popcnt32((uint32_t) x) +
+         popcnt32((uint32_t)(x >> 32));
+}
+
+#elif defined(_MSC_VER) && \
+      defined(_M_X64)
+
+#include <nmmintrin.h>
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  return _mm_popcnt_u64(x);
+}
+
+#elif defined(_MSC_VER) && \
+      defined(_M_IX86)
+
+#include <nmmintrin.h>
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  return _mm_popcnt_u32((uint32_t) x) +
+         _mm_popcnt_u32((uint32_t)(x >> 32));
+}
+
+/* non x86 CPUs */
+#elif defined(HAVE_BUILTIN_POPCOUNT)
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  return __builtin_popcountll(x);
+}
+
+/* no hardware POPCNT,
+ * use pure integer algorithm */
+#else
+
+static inline uint64_t popcnt64(uint64_t x)
+{
+  return popcount64(x);
+}
+
+#endif
+
+static inline uint64_t popcnt64_unrolled(const uint64_t* data, uint64_t size)
+{
+  uint64_t i = 0;
+  uint64_t limit = size - size % 4;
+  uint64_t cnt = 0;
+
+  for (; i < limit; i += 4)
+  {
+    cnt += popcnt64(data[i+0]);
+    cnt += popcnt64(data[i+1]);
+    cnt += popcnt64(data[i+2]);
+    cnt += popcnt64(data[i+3]);
+  }
+
+  for (; i < size; i++)
+    cnt += popcnt64(data[i]);
+
+  return cnt;
+}
+
+#if defined(HAVE_CPUID)
+
+#if defined(_MSC_VER)
+  #include <intrin.h>
+  #include <immintrin.h>
+#endif
+
+/* %ecx bit flags */
+#define bit_POPCNT (1 << 23)
+
+/* %ebx bit flags */
+#define bit_AVX2   (1 << 5)
+#define bit_AVX512 (1 << 30)
+
+/* xgetbv bit flags */
+#define XSTATE_SSE (1 << 1)
+#define XSTATE_YMM (1 << 2)
+#define XSTATE_ZMM (7 << 5)
+
+static inline void run_cpuid(int eax, int ecx, int* abcd)
+{
+#if defined(_MSC_VER)
+  __cpuidex(abcd, eax, ecx);
+#else
+  int ebx = 0;
+  int edx = 0;
+
+  #if defined(__i386__) && \
+      defined(__PIC__)
+    /* in case of PIC under 32-bit EBX cannot be clobbered */
+    __asm__ ("movl %%ebx, %%edi;"
+             "cpuid;"
+             "xchgl %%ebx, %%edi;"
+             : "=D" (ebx),
+               "+a" (eax),
+               "+c" (ecx),
+               "=d" (edx));
+  #else
+    __asm__ ("cpuid;"
+             : "+b" (ebx),
+               "+a" (eax),
+               "+c" (ecx),
+               "=d" (edx));
+  #endif
+
+  abcd[0] = eax;
+  abcd[1] = ebx;
+  abcd[2] = ecx;
+  abcd[3] = edx;
+#endif
+}
+
+#if defined(HAVE_AVX2) || \
+    defined(HAVE_AVX512)
+
+static inline int get_xcr0()
+{
+  int xcr0;
+
+#if defined(_MSC_VER)
+  xcr0 = (int) _xgetbv(0);
+#else
+  __asm__ ("xgetbv" : "=a" (xcr0) : "c" (0) : "%edx" );
+#endif
+
+  return xcr0;
+}
+
+#endif
+
+static inline int get_cpuid()
+{
+  int flags = 0;
+  int abcd[4];
+
+  run_cpuid(1, 0, abcd);
+
+  if ((abcd[2] & bit_POPCNT) == bit_POPCNT)
+    flags |= bit_POPCNT;
+
+#if defined(HAVE_AVX2) || \
+    defined(HAVE_AVX512)
+
+  int osxsave_mask = (1 << 27);
+
+  /* ensure OS supports extended processor state management */
+  if ((abcd[2] & osxsave_mask) != osxsave_mask)
+    return 0;
+
+  int ymm_mask = XSTATE_SSE | XSTATE_YMM;
+  int zmm_mask = XSTATE_SSE | XSTATE_YMM | XSTATE_ZMM;
+
+  int xcr0 = get_xcr0();
+
+  if ((xcr0 & ymm_mask) == ymm_mask)
+  {
+    run_cpuid(7, 0, abcd);
+
+    if ((abcd[1] & bit_AVX2) == bit_AVX2)
+      flags |= bit_AVX2;
+
+    if ((xcr0 & zmm_mask) == zmm_mask)
+    {
+      if ((abcd[1] & bit_AVX512) == bit_AVX512)
+        flags |= bit_AVX512;
+    }
+  }
+
+#endif
+
+  return flags;
+}
+
+#endif /* cpuid */
+
+#if defined(HAVE_AVX2)
+
+#include <immintrin.h>
+
+#if !defined(_MSC_VER)
+  __attribute__ ((target ("avx2")))
+#endif
+static inline void CSA256(__m256i* h, __m256i* l, __m256i a, __m256i b, __m256i c)
+{
+  __m256i u = _mm256_xor_si256(a, b);
+  *h = _mm256_or_si256(_mm256_and_si256(a, b), _mm256_and_si256(u, c));
+  *l = _mm256_xor_si256(u, c);
+}
+
+#if !defined(_MSC_VER)
+  __attribute__ ((target ("avx2")))
+#endif
+static inline __m256i popcnt256(__m256i v)
+{
+  __m256i lookup1 = _mm256_setr_epi8(
+      4, 5, 5, 6, 5, 6, 6, 7,
+      5, 6, 6, 7, 6, 7, 7, 8,
+      4, 5, 5, 6, 5, 6, 6, 7,
+      5, 6, 6, 7, 6, 7, 7, 8
+  );
+
+  __m256i lookup2 = _mm256_setr_epi8(
+      4, 3, 3, 2, 3, 2, 2, 1,
+      3, 2, 2, 1, 2, 1, 1, 0,
+      4, 3, 3, 2, 3, 2, 2, 1,
+      3, 2, 2, 1, 2, 1, 1, 0
+  );
+
+  __m256i low_mask = _mm256_set1_epi8(0x0f);
+  __m256i lo = _mm256_and_si256(v, low_mask);
+  __m256i hi = _mm256_and_si256(_mm256_srli_epi16(v, 4), low_mask);
+  __m256i popcnt1 = _mm256_shuffle_epi8(lookup1, lo);
+  __m256i popcnt2 = _mm256_shuffle_epi8(lookup2, hi);
+
+  return _mm256_sad_epu8(popcnt1, popcnt2);
+}
+
+/*
+ * AVX2 Harley-Seal popcount (4th iteration).
+ * The algorithm is based on the paper "Faster Population Counts
+ * using AVX2 Instructions" by Daniel Lemire, Nathan Kurz and
+ * Wojciech Mula (23 Nov 2016).
+ * @see https://arxiv.org/abs/1611.07612
+ */
+#if !defined(_MSC_VER)
+  __attribute__ ((target ("avx2")))
+#endif
+static inline uint64_t popcnt_avx2(const __m256i* data, uint64_t size)
+{
+  __m256i cnt = _mm256_setzero_si256();
+  __m256i ones = _mm256_setzero_si256();
+  __m256i twos = _mm256_setzero_si256();
+  __m256i fours = _mm256_setzero_si256();
+  __m256i eights = _mm256_setzero_si256();
+  __m256i sixteens = _mm256_setzero_si256();
+  __m256i twosA, twosB, foursA, foursB, eightsA, eightsB;
+
+  uint64_t i = 0;
+  uint64_t limit = size - size % 16;
+  uint64_t* cnt64;
+
+  for(; i < limit; i += 16)
+  {
+    CSA256(&twosA, &ones, ones, data[i+0], data[i+1]);
+    CSA256(&twosB, &ones, ones, data[i+2], data[i+3]);
+    CSA256(&foursA, &twos, twos, twosA, twosB);
+    CSA256(&twosA, &ones, ones, data[i+4], data[i+5]);
+    CSA256(&twosB, &ones, ones, data[i+6], data[i+7]);
+    CSA256(&foursB, &twos, twos, twosA, twosB);
+    CSA256(&eightsA, &fours, fours, foursA, foursB);
+    CSA256(&twosA, &ones, ones, data[i+8], data[i+9]);
+    CSA256(&twosB, &ones, ones, data[i+10], data[i+11]);
+    CSA256(&foursA, &twos, twos, twosA, twosB);
+    CSA256(&twosA, &ones, ones, data[i+12], data[i+13]);
+    CSA256(&twosB, &ones, ones, data[i+14], data[i+15]);
+    CSA256(&foursB, &twos, twos, twosA, twosB);
+    CSA256(&eightsB, &fours, fours, foursA, foursB);
+    CSA256(&sixteens, &eights, eights, eightsA, eightsB);
+
+    cnt = _mm256_add_epi64(cnt, popcnt256(sixteens));
+  }
+
+  cnt = _mm256_slli_epi64(cnt, 4);
+  cnt = _mm256_add_epi64(cnt, _mm256_slli_epi64(popcnt256(eights), 3));
+  cnt = _mm256_add_epi64(cnt, _mm256_slli_epi64(popcnt256(fours), 2));
+  cnt = _mm256_add_epi64(cnt, _mm256_slli_epi64(popcnt256(twos), 1));
+  cnt = _mm256_add_epi64(cnt, popcnt256(ones));
+
+  for(; i < size; i++)
+    cnt = _mm256_add_epi64(cnt, popcnt256(data[i]));
+
+  cnt64 = (uint64_t*) &cnt;
+
+  return cnt64[0] +
+         cnt64[1] +
+         cnt64[2] +
+         cnt64[3];
+}
+
+/* Align memory to 32 bytes boundary */
+static inline void align_avx2(const uint8_t** p, uint64_t* size, uint64_t* cnt)
+{
+  for (; (uintptr_t) *p % 8; (*p)++)
+  {
+    *cnt += popcnt64(**p);
+    *size -= 1;
+  }
+  for (; (uintptr_t) *p % 32; (*p) += 8)
+  {
+    *cnt += popcnt64(
+        *(const uint64_t*) *p);
+    *size -= 8;
+  }
+}
+
+#endif
+
+#if defined(HAVE_AVX512)
+
+#include <immintrin.h>
+
+#if !defined(_MSC_VER)
+  __attribute__ ((target ("avx512bw")))
+#endif
+static inline __m512i popcnt512(__m512i v)
+{
+  __m512i m1 = _mm512_set1_epi8(0x55);
+  __m512i m2 = _mm512_set1_epi8(0x33);
+  __m512i m4 = _mm512_set1_epi8(0x0F);
+  __m512i t1 = _mm512_sub_epi8(v, (_mm512_srli_epi16(v, 1) & m1));
+  __m512i t2 = _mm512_add_epi8(t1 & m2, (_mm512_srli_epi16(t1, 2) & m2));
+  __m512i t3 = _mm512_add_epi8(t2, _mm512_srli_epi16(t2, 4)) & m4;
+
+  return _mm512_sad_epu8(t3, _mm512_setzero_si512());
+}
+
+#if !defined(_MSC_VER)
+  __attribute__ ((target ("avx512bw")))
+#endif
+static inline void CSA512(__m512i* h, __m512i* l, __m512i a, __m512i b, __m512i c)
+{
+  *l = _mm512_ternarylogic_epi32(c, b, a, 0x96);
+  *h = _mm512_ternarylogic_epi32(c, b, a, 0xe8);
+}
+
+/*
+ * AVX512 Harley-Seal popcount (4th iteration).
+ * The algorithm is based on the paper "Faster Population Counts
+ * using AVX2 Instructions" by Daniel Lemire, Nathan Kurz and
+ * Wojciech Mula (23 Nov 2016).
+ * @see https://arxiv.org/abs/1611.07612
+ */
+#if !defined(_MSC_VER)
+  __attribute__ ((target ("avx512bw")))
+#endif
+static inline uint64_t popcnt_avx512(const __m512i* data, const uint64_t size)
+{
+  __m512i cnt = _mm512_setzero_si512();
+  __m512i ones = _mm512_setzero_si512();
+  __m512i twos = _mm512_setzero_si512();
+  __m512i fours = _mm512_setzero_si512();
+  __m512i eights = _mm512_setzero_si512();
+  __m512i sixteens = _mm512_setzero_si512();
+  __m512i twosA, twosB, foursA, foursB, eightsA, eightsB;
+
+  uint64_t i = 0;
+  uint64_t limit = size - size % 16;
+  uint64_t* cnt64;
+
+  for(; i < limit; i += 16)
+  {
+    CSA512(&twosA, &ones, ones, data[i+0], data[i+1]);
+    CSA512(&twosB, &ones, ones, data[i+2], data[i+3]);
+    CSA512(&foursA, &twos, twos, twosA, twosB);
+    CSA512(&twosA, &ones, ones, data[i+4], data[i+5]);
+    CSA512(&twosB, &ones, ones, data[i+6], data[i+7]);
+    CSA512(&foursB, &twos, twos, twosA, twosB);
+    CSA512(&eightsA, &fours, fours, foursA, foursB);
+    CSA512(&twosA, &ones, ones, data[i+8], data[i+9]);
+    CSA512(&twosB, &ones, ones, data[i+10], data[i+11]);
+    CSA512(&foursA, &twos, twos, twosA, twosB);
+    CSA512(&twosA, &ones, ones, data[i+12], data[i+13]);
+    CSA512(&twosB, &ones, ones, data[i+14], data[i+15]);
+    CSA512(&foursB, &twos, twos, twosA, twosB);
+    CSA512(&eightsB, &fours, fours, foursA, foursB);
+    CSA512(&sixteens, &eights, eights, eightsA, eightsB);
+
+    cnt = _mm512_add_epi64(cnt, popcnt512(sixteens));
+  }
+
+  cnt = _mm512_slli_epi64(cnt, 4);
+  cnt = _mm512_add_epi64(cnt, _mm512_slli_epi64(popcnt512(eights), 3));
+  cnt = _mm512_add_epi64(cnt, _mm512_slli_epi64(popcnt512(fours), 2));
+  cnt = _mm512_add_epi64(cnt, _mm512_slli_epi64(popcnt512(twos), 1));
+  cnt = _mm512_add_epi64(cnt, popcnt512(ones));
+
+  for(; i < size; i++)
+    cnt = _mm512_add_epi64(cnt, popcnt512(data[i]));
+
+  cnt64 = (uint64_t*) &cnt;
+
+  return cnt64[0] +
+         cnt64[1] +
+         cnt64[2] +
+         cnt64[3] +
+         cnt64[4] +
+         cnt64[5] +
+         cnt64[6] +
+         cnt64[7];
+}
+
+/* Align memory to 64 bytes boundary */
+static inline void align_avx512(const uint8_t** p, uint64_t* size, uint64_t* cnt)
+{
+  for (; (uintptr_t) *p % 8; (*p)++)
+  {
+    *cnt += popcnt64(**p);
+    *size -= 1;
+  }
+  for (; (uintptr_t) *p % 64; (*p) += 8)
+  {
+    *cnt += popcnt64(
+        *(const uint64_t*) *p);
+    *size -= 8;
+  }
+}
+
+#endif
+
+/* x86 CPUs */
+#if defined(X86_OR_X64)
+
+/* Align memory to 8 bytes boundary */
+static inline void align_8(const uint8_t** p, uint64_t* size, uint64_t* cnt)
+{
+  for (; *size > 0 && (uintptr_t) *p % 8; (*p)++)
+  {
+    *cnt += popcount64(**p);
+    *size -= 1;
+  }
+}
+
+static inline uint64_t popcount64_unrolled(const uint64_t* data, uint64_t size)
+{
+  uint64_t i = 0;
+  uint64_t limit = size - size % 4;
+  uint64_t cnt = 0;
+
+  for (; i < limit; i += 4)
+  {
+    cnt += popcount64(data[i+0]);
+    cnt += popcount64(data[i+1]);
+    cnt += popcount64(data[i+2]);
+    cnt += popcount64(data[i+3]);
+  }
+
+  for (; i < size; i++)
+    cnt += popcount64(data[i]);
+
+  return cnt;
+}
+
+/*
+ * Count the number of 1 bits in the data array
+ * @data: An array
+ * @size: Size of data in bytes
+ */
+static inline uint64_t popcnt(const void* data, uint64_t size)
+{
+  const uint8_t* ptr = (const uint8_t*) data;
+  uint64_t cnt = 0;
+  uint64_t i;
+
+#if defined(HAVE_CPUID)
+  #if defined(__cplusplus)
+    /* C++11 thread-safe singleton */
+    static const int cpuid = get_cpuid();
+  #else
+    static int cpuid_ = -1;
+    int cpuid = cpuid_;
+    if (cpuid == -1)
+    {
+      cpuid = get_cpuid();
+
+      #if defined(_MSC_VER)
+        _InterlockedCompareExchange(&cpuid_, cpuid, -1);
+      #else
+        __sync_val_compare_and_swap(&cpuid_, -1, cpuid);
+      #endif
+    }
+  #endif
+#endif
+
+#if defined(HAVE_AVX512)
+
+  /* AVX512 requires arrays >= 1024 bytes */
+  if ((cpuid & bit_AVX512) &&
+      size >= 1024)
+  {
+    align_avx512(&ptr, &size, &cnt);
+    cnt += popcnt_avx512((const __m512i*) ptr, size / 64);
+    ptr += size - size % 64;
+    size = size % 64;
+  }
+
+#endif
+
+#if defined(HAVE_AVX2)
+
+  /* AVX2 requires arrays >= 512 bytes */
+  if ((cpuid & bit_AVX2) &&
+      size >= 512)
+  {
+    align_avx2(&ptr, &size, &cnt);
+    cnt += popcnt_avx2((const __m256i*) ptr, size / 32);
+    ptr += size - size % 32;
+    size = size % 32;
+  }
+
+#endif
+
+#if defined(HAVE_POPCNT)
+
+  if (cpuid & bit_POPCNT)
+  {
+    cnt += popcnt64_unrolled((const uint64_t*) ptr, size / 8);
+    ptr += size - size % 8;
+    size = size % 8;
+    for (i = 0; i < size; i++)
+      cnt += popcnt64(ptr[i]);
+
+    return cnt;
+  }
+
+#endif
+
+  /* pure integer popcount algorithm */
+  if (size >= 8)
+  {
+    align_8(&ptr, &size, &cnt);
+    cnt += popcount64_unrolled((const uint64_t*) ptr, size / 8);
+    ptr += size - size % 8;
+    size = size % 8;
+  }
+
+  /* pure integer popcount algorithm */
+  for (i = 0; i < size; i++)
+    cnt += popcount64(ptr[i]);
+
+  return cnt;
+}
+
+#elif defined(__ARM_NEON) || \
+      defined(__aarch64__)
+
+#include <arm_neon.h>
+
+static inline uint64x2_t vpadalq(uint64x2_t sum, uint8x16_t t)
+{
+  return vpadalq_u32(sum, vpaddlq_u16(vpaddlq_u8(t)));
+}
+
+/*
+ * Count the number of 1 bits in the data array
+ * @data: An array
+ * @size: Size of data in bytes
+ */
+static inline uint64_t popcnt(const void* data, uint64_t size)
+{
+  const uint8_t* ptr = (const uint8_t*) data;
+  uint64_t cnt = 0;
+  uint64_t tmp[2];
+  uint64_t chunk_size = 64;
+  uint64_t n = size / chunk_size;
+  uint64_t is_sum = 30;
+  uint64_t i;
+
+  uint64x2_t sum = vcombine_u64(vcreate_u64(0), vcreate_u64(0));
+  uint8x16_t zero = vcombine_u8(vcreate_u8(0), vcreate_u8(0));
+
+  uint8x16_t t0 = zero;
+  uint8x16_t t1 = zero;
+  uint8x16_t t2 = zero;
+  uint8x16_t t3 = zero;
+  uint8x16x4_t input;
+
+  for (i = 0; i < n; i++, ptr += chunk_size)
+  {
+    input = vld4q_u8(ptr);
+
+    t0 = vaddq_u8(t0, vcntq_u8(input.val[0]));
+    t1 = vaddq_u8(t1, vcntq_u8(input.val[1]));
+    t2 = vaddq_u8(t2, vcntq_u8(input.val[2]));
+    t3 = vaddq_u8(t3, vcntq_u8(input.val[3]));
+
+    if (i == is_sum)
+    {
+      is_sum += 30;
+      sum = vpadalq(sum, t0);
+      sum = vpadalq(sum, t1);
+      sum = vpadalq(sum, t2);
+      sum = vpadalq(sum, t3);
+      t0 = t1 = t2 = t3 = zero;
+    }
+  }
+
+  sum = vpadalq(sum, t0);
+  sum = vpadalq(sum, t1);
+  sum = vpadalq(sum, t2);
+  sum = vpadalq(sum, t3);
+
+  vst1q_u64(tmp, sum);
+  for (i = 0; i < 2; i++)
+    cnt += tmp[i];
+
+  size %= chunk_size;
+  cnt += popcnt64_unrolled((const uint64_t*) ptr, size / 8);
+  ptr += size - size % 8;
+  size = size % 8;
+  for (i = 0; i < size; i++)
+    cnt += popcnt64(ptr[i]);
+
+  return cnt;
+}
+
+/* all other CPUs */
+#else
+
+/* Align memory to 8 bytes boundary */
+static inline void align_8(const uint8_t** p, uint64_t* size, uint64_t* cnt)
+{
+  for (; *size > 0 && (uintptr_t) *p % 8; (*p)++)
+  {
+    *cnt += popcnt64(**p);
+    *size -= 1;
+  }
+}
+
+/*
+ * Count the number of 1 bits in the data array
+ * @data: An array
+ * @size: Size of data in bytes
+ */
+static inline uint64_t popcnt(const void* data, uint64_t size)
+{
+  const uint8_t* ptr = (const uint8_t*) data;
+  uint64_t cnt = 0;
+  uint64_t i;
+
+  align_8(&ptr, &size, &cnt);
+  cnt += popcnt64_unrolled((const uint64_t*) ptr, size / 8);
+  ptr += size - size % 8;
+  size = size % 8;
+  for (i = 0; i < size; i++)
+    cnt += popcnt64(ptr[i]);
+
+  return cnt;
+}
+
+#endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* LIBPOPCNT_H */

--- a/anonlink/__init__.py
+++ b/anonlink/__init__.py
@@ -10,4 +10,4 @@ from anonlink import stats
 from anonlink import typechecking
 
 __version__ = pkg_resources.get_distribution('anonlink').version
-__author__ = 'N1 Analytics'
+__author__ = 'Data61'

--- a/anonlink/solving/_multiparty_solving_inner.cpp
+++ b/anonlink/solving/_multiparty_solving_inner.cpp
@@ -90,7 +90,7 @@ public:
         return group;
     }
     
-    Group *merge_into(Group * __restrict__ absorber, Group * __restrict__ absorbee) {
+    Group *merge_into(Group * absorber, Group * absorbee) {
         // Merges two existing groups. The records in absorbee are moved into absorber.
         // The absorbee is freed and should no longer be dereferenced.
         // Returns the merged group (the absorber).

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -11,12 +11,8 @@ stages:
 - stage: wheels
   displayName: Build Wheel Packages
   variables:
-    CIBW_TEST_REQUIRES: 'pytest pytest-cov pytest-timeout hypothesis codecov'
-    CIBW_TEST_COMMAND: 'pytest {project}/tests --cov={project} --junitxml={project}/testoutput.xml --cov-report=xml:{project}/coverage.xml -k "test_similarity_dice or test_solving" -W ignore::DeprecationWarning'
-    CIBW_BEFORE_BUILD: 'python -m pip install --upgrade pip && pip install -e .'
     # Need to install development libraries for manylinux container
-    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel && pip install -e .'
-
+    CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel'
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp37-* cp36-*'
     CIBW_SKIP: '*-win32 *-manylinux1_i686'
@@ -28,21 +24,6 @@ stages:
       CIBW_BUILD: 'cp37-*'
     steps:
     - template: .azurePipeline/cibuildwheel_steps.yml
-  - job: windows
-    pool: {vmImage: 'vs2017-win2016'}
-    steps:
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
-      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
-      #- script: choco install vcpython27 -f -y
-      #  displayName: Install Visual C++ for Python 2.7
-      - bash: |
-          python -m pip install --upgrade pip
-          pip install cibuildwheel==0.12.0
-          cibuildwheel --output-dir wheelhouse .
-      - task: PublishBuildArtifacts@1
-        inputs: {pathtoPublish: 'wheelhouse'}
-
-
   - job: linux_36
     displayName: Linux + Python3.6
     pool: {vmImage: 'Ubuntu-16.04'}
@@ -50,23 +31,20 @@ stages:
       CIBW_BUILD: 'cp36-*'
     steps:
     - template: .azurePipeline/cibuildwheel_steps.yml
-
-  - job: macos_37
-    displayName: MacOS + Python3.7
-    pool: {vmImage: 'macOS-10.13'}
-    variables:
-      CIBW_BUILD: 'cp37-*'
+#  - job: macos
+#    displayName: MacOS
+#    pool: {vmImage: 'macOS-10.13'}
+#    variables:
+#      MACOSX_DEPLOYMENT_TARGET: '10.13'
+#    steps:
+#    - template: .azurePipeline/cibuildwheel_steps.yml
+  - job: windows
+    displayName: Windows
+    pool: {vmImage: 'vs2017-win2016'}
     steps:
-    - template: .azurePipeline/cibuildwheel_steps.yml
-
-  - job: macos_36
-    displayName: MacOS + Python3.6
-    pool: {vmImage: 'macOS-10.13'}
-    variables:
-      CIBW_BUILD: 'cp36-*'
-    steps:
-    - template: .azurePipeline/cibuildwheel_steps.yml
-
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - template: .azurePipeline/cibuildwheel_steps.yml
 
 - stage: test
   displayName: Unit tests
@@ -90,24 +68,48 @@ stages:
           artifactName: $(artifactName)
           pythonVersion: $(pythonVersion)
           operatingSystem: 'ubuntu-16.04'
+#  - job:
+#    displayName: MacOS
+#    pool:
+#      vmImage: 'macOS-10.13'
+#    strategy:
+#      matrix:
+#        Python3.6:
+#          pythonVersion: '3.6'
+#          artifactName: 'wheels.macos'
+#          artifactPattern: '**/*cp36*.whl'
+#        Python3.7:
+#          pythonVersion: '3.7'
+#          artifactName: 'wheels.macos'
+#          artifactPattern: '**/*cp37*.whl'
+#    steps:
+#      - template: .azurePipeline/unittest_wheel_steps.yml
+#        parameters:
+#          artifactName: $(artifactName)
+#          artifactPattern: $(artifactPattern)
+#          pythonVersion: $(pythonVersion)
+#          operatingSystem: 'macOS-10.13'
   - job:
-    displayName: MacOS
+    displayName: Windows
     pool:
-      vmImage: 'macOS-10.13'
+      vmImage: 'vs2017-win2016'
     strategy:
       matrix:
         Python3.6:
           pythonVersion: '3.6'
-          artifactName: 'wheels.macos36'
+          artifactName: 'wheels.windows'
+          artifactPattern: '**/*cp36m*.whl'
         Python3.7:
           pythonVersion: '3.7'
-          artifactName: 'wheels.macos37'
+          artifactName: 'wheels.windows'
+          artifactPattern: '**/*cp37m*.whl'
     steps:
       - template: .azurePipeline/unittest_wheel_steps.yml
         parameters:
           artifactName: $(artifactName)
+          artifactPattern: $(artifactPattern)
           pythonVersion: $(pythonVersion)
-          operatingSystem: 'macOS-10.13'
+          operatingSystem: 'vs2017-win2016'
 
 - stage: static_checks
   displayName: Static Checks
@@ -124,3 +126,26 @@ stages:
       - script: pip install -U mypy
       - script: mypy anonlink --ignore-missing-imports
         displayName: mypy
+
+- stage: publish
+  displayName: Publish packages to test feed
+  dependsOn: ['test']
+  jobs:
+  - job:
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+      # the name of an Azure artifacts feed to publish artifacts to
+      artifactFeed: anonlink
+    steps:
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - script: 'pip install twine'
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifactName: 'drop'
+          patterns: '**/*.whl'
+          path: $(Pipeline.Workspace)
+      - task: TwineAuthenticate@1
+        inputs:
+          artifactFeed: $(artifactFeed)
+      - script: 'twine upload -r $(artifactFeed) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/*.whl --skip-existing'

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -28,6 +28,21 @@ stages:
       CIBW_BUILD: 'cp37-*'
     steps:
     - template: .azurePipeline/cibuildwheel_steps.yml
+  - job: windows
+    pool: {vmImage: 'vs2017-win2016'}
+    steps:
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      #- script: choco install vcpython27 -f -y
+      #  displayName: Install Visual C++ for Python 2.7
+      - bash: |
+          python -m pip install --upgrade pip
+          pip install cibuildwheel==0.12.0
+          cibuildwheel --output-dir wheelhouse .
+      - task: PublishBuildArtifacts@1
+        inputs: {pathtoPublish: 'wheelhouse'}
+
+
   - job: linux_36
     displayName: Linux + Python3.6
     pool: {vmImage: 'Ubuntu-16.04'}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bitarray==0.9.3
+bitarray==1.0.1
 cffi>=1.7
 pytest>=3.4
 pytest-cov>=2.5

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink",
-    version='0.12.5',
+    version='0.12.6',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import platform
+
 from setuptools import setup, Extension, find_packages
 import os
 
@@ -30,14 +32,21 @@ test_requirements = [
         "hypothesis"
     ]
 
+current_os = platform.system()
+if current_os == "Windows":
+    extra_compile_args = ['/std:c++17', '/O2', '/arch:AVX512']
+else:
+    extra_compile_args = ['-O3', '-std=c++11']
+
+
 extensions = [Extension(
     name="solving._multiparty_solving",
     sources=["anonlink/solving/_multiparty_solving." + cython_cpp_ext,
              "anonlink/solving/_multiparty_solving_inner.cpp"],
     include_dirs=["anonlink/solving"],
     language="c++",
-    extra_compile_args=["-std=c++11"],
-    extra_link_args=["-std=c++11"],
+    extra_compile_args=extra_compile_args,
+    extra_link_args=extra_compile_args,
     define_macros=[('NDEBUG', None)]
     )]
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink",
-    version='0.12.6',
+    version='0.13.0-dev',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',

--- a/tests/test_cffi.py
+++ b/tests/test_cffi.py
@@ -1,0 +1,23 @@
+from bitarray import bitarray
+from anonlink._entitymatcher import ffi, lib
+
+
+byte_sizes = [2, 32, 64, 512, 1024, 100000]
+
+
+def test_popcnt():
+    for num_bytes in byte_sizes:
+        data = bitarray("10101010" * num_bytes)
+        assert lib.popcnt(data.tobytes(), num_bytes) == data.count()
+
+
+def test_popcnt_char_array():
+
+    for num_bytes in byte_sizes:
+        data = bitarray("10101010" * num_bytes)
+        carr = ffi.new('char[]', data.tobytes())
+
+        assert lib.popcnt(carr, num_bytes) == data.count()
+
+
+

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -7,6 +7,7 @@ from clkhash.key_derivation import generate_key_lists
 from hypothesis import given, strategies
 
 from anonlink import similarities
+from anonlink.similarities import dice_coefficient_accelerated
 
 __author__ = 'Brian Thorne'
 
@@ -284,13 +285,41 @@ def _to_bitarray(bytes_):
     ba.frombytes(bytes_)
     return ba
 
+#
+# @given(strategies.data(), strategies.floats(min_value=0, max_value=1))
+# @pytest.mark.parametrize('sim_fun', SIM_FUNS)
+# def test_bytes_bitarray_agree(sim_fun, data, threshold):
+#     bytes_length = data.draw(strategies.integers(
+#         min_value=0,
+#         max_value=1024  # Let's not get too carried away...
+#     ))
+#     bytes_length *= 8  # TODO: remove this line when we deal with #163
+#     filters0_bytes = data.draw(strategies.lists(strategies.binary(
+#         min_size=bytes_length, max_size=bytes_length)))
+#     filters1_bytes = data.draw(strategies.lists(strategies.binary(
+#         min_size=bytes_length, max_size=bytes_length)))
+#
+#     filters0_ba = tuple(map(_to_bitarray, filters0_bytes))
+#     filters1_ba = tuple(map(_to_bitarray, filters1_bytes))
+#
+#     print("Threshold", threshold)
+#     print("Bytes Length", bytes_length)
+#     print(len(filters0_bytes))
+#     print(len(filters1_bytes))
+#     print(len(filters0_ba))
+#     print(len(filters1_ba))
+#
+#     #res_bytes = sim_fun([filters0_bytes, filters1_bytes], threshold)
+#     res_ba = sim_fun([filters0_ba, filters1_ba], threshold)
+#     #assert (res_bytes == res_ba)
+#
 
-@given(strategies.data(), strategies.floats(min_value=0, max_value=1))
-@pytest.mark.parametrize('sim_fun', SIM_FUNS)
-def test_bytes_bitarray_agree(sim_fun, data, threshold):
+@given(strategies.data())
+def test_accelerated(data):
+    threshold = 0.999
     bytes_length = data.draw(strategies.integers(
-        min_value=0,
-        max_value=1024  # Let's not get too carried away...
+        min_value=64,
+        max_value=64  # Let's not get too carried away...
     ))
     bytes_length *= 8  # TODO: remove this line when we deal with #163
     filters0_bytes = data.draw(strategies.lists(strategies.binary(
@@ -301,5 +330,11 @@ def test_bytes_bitarray_agree(sim_fun, data, threshold):
     filters0_ba = tuple(map(_to_bitarray, filters0_bytes))
     filters1_ba = tuple(map(_to_bitarray, filters1_bytes))
 
-    assert (sim_fun([filters0_bytes, filters1_bytes], threshold)
-            == sim_fun([filters0_ba, filters1_ba], threshold))
+    print("Threshold", threshold)
+    print("Bytes Length", bytes_length)
+    print(len(filters0_bytes))
+    print(len(filters1_bytes))
+    print(len(filters0_ba))
+    print(len(filters1_ba))
+
+    res_ba = dice_coefficient_accelerated([filters0_ba, filters1_ba], threshold)

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -283,41 +283,13 @@ def _to_bitarray(bytes_):
     ba.frombytes(bytes_)
     return ba
 
-#
-# @given(strategies.data(), strategies.floats(min_value=0, max_value=1))
-# @pytest.mark.parametrize('sim_fun', SIM_FUNS)
-# def test_bytes_bitarray_agree(sim_fun, data, threshold):
-#     bytes_length = data.draw(strategies.integers(
-#         min_value=0,
-#         max_value=1024  # Let's not get too carried away...
-#     ))
-#     bytes_length *= 8  # TODO: remove this line when we deal with #163
-#     filters0_bytes = data.draw(strategies.lists(strategies.binary(
-#         min_size=bytes_length, max_size=bytes_length)))
-#     filters1_bytes = data.draw(strategies.lists(strategies.binary(
-#         min_size=bytes_length, max_size=bytes_length)))
-#
-#     filters0_ba = tuple(map(_to_bitarray, filters0_bytes))
-#     filters1_ba = tuple(map(_to_bitarray, filters1_bytes))
-#
-#     print("Threshold", threshold)
-#     print("Bytes Length", bytes_length)
-#     print(len(filters0_bytes))
-#     print(len(filters1_bytes))
-#     print(len(filters0_ba))
-#     print(len(filters1_ba))
-#
-#     #res_bytes = sim_fun([filters0_bytes, filters1_bytes], threshold)
-#     res_ba = sim_fun([filters0_ba, filters1_ba], threshold)
-#     #assert (res_bytes == res_ba)
-#
 
-@given(strategies.data())
-def test_accelerated(data):
-    threshold = 0.999
+@given(strategies.data(), strategies.floats(min_value=0, max_value=1))
+@pytest.mark.parametrize('sim_fun', SIM_FUNS)
+def test_bytes_bitarray_agree(sim_fun, data, threshold):
     bytes_length = data.draw(strategies.integers(
-        min_value=64,
-        max_value=64  # Let's not get too carried away...
+        min_value=0,
+        max_value=1024  # Let's not get too carried away...
     ))
     bytes_length *= 8  # TODO: remove this line when we deal with #163
     filters0_bytes = data.draw(strategies.lists(strategies.binary(
@@ -328,11 +300,7 @@ def test_accelerated(data):
     filters0_ba = tuple(map(_to_bitarray, filters0_bytes))
     filters1_ba = tuple(map(_to_bitarray, filters1_bytes))
 
-    print("Threshold", threshold)
-    print("Bytes Length", bytes_length)
-    print(len(filters0_bytes))
-    print(len(filters1_bytes))
-    print(len(filters0_ba))
-    print(len(filters1_ba))
+    res_bytes = sim_fun([filters0_bytes, filters1_bytes], threshold)
+    res_ba = sim_fun([filters0_ba, filters1_ba], threshold)
+    assert (res_bytes == res_ba)
 
-    res_ba = dice_coefficient_accelerated([filters0_ba, filters1_ba], threshold)

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -1,8 +1,6 @@
-import unittest
-
 import pytest
 from bitarray import bitarray
-from clkhash import bloomfilter, randomnames, schema
+from clkhash import bloomfilter, randomnames
 from clkhash.key_derivation import generate_key_lists
 from hypothesis import given, strategies
 

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -5,9 +5,6 @@ from clkhash.key_derivation import generate_key_lists
 from hypothesis import given, strategies
 
 from anonlink import similarities
-from anonlink.similarities import dice_coefficient_accelerated
-
-__author__ = 'Brian Thorne'
 
 FLOAT_ARRAY_TYPES = 'fd'
 UINT_ARRAY_TYPES = 'BHILQ'


### PR DESCRIPTION
Introduces a new header only library `libpopcount` from https://github.com/kimwalisch/libpopcnt

Just dropping in this library for all platforms reduced performance on Linux (as measured by throughput in the `anonlink.benchmark`), so I've  new path through `dice_one_against_many.cpp` for the `MSVC` compiler to use - attempting to pass larger buffers to popcnt so it can take advantage of AVX2 etc.

With this addition `anonlink` installs and passes all tests on Windows. Performance isn't as good as Linux - about half the speed.

In a separate PR #246  the changes for building and publishing binary wheels for Windows was already reviewed.

### Benchmarks 

Measured on my laptop (native OS is Windows, and Linux measurements via the Linux subsystem for Windows).


**Windows**
```
Anonlink benchmark -- see README for explanation
------------------------------------------------

Threshold: 0.5
Size 1 | Size 2 | Comparisons      | Total Time (s)          | Throughput
       |        |        (match %) | (comparisons / matching)|  (1e6 cmp/s)
-------+--------+------------------+-------------------------+-------------
  1000 |   1000 |    1e6  ( 0.00%) |  1.341  (58.6% / 41.4%) |     1.272
  2000 |   2000 |    4e6  ( 0.00%) |  6.238  (51.9% / 48.1%) |     1.236
  3000 |   3000 |    9e6  ( 0.00%) | 16.158  (46.5% / 53.5%) |     1.197
  4000 |   4000 |   16e6  ( 0.00%) | 29.770  (43.8% / 56.2%) |     1.227

Threshold: 0.7
Size 1 | Size 2 | Comparisons      | Total Time (s)          | Throughput
       |        |        (match %) | (comparisons / matching)|  (1e6 cmp/s)
-------+--------+------------------+-------------------------+-------------
  1000 |   1000 |    1e6  ( 0.00%) |  0.021  (99.1% /  0.9%) |    48.739
  2000 |   2000 |    4e6  ( 0.00%) |  0.071  (99.4% /  0.6%) |    56.741
  3000 |   3000 |    9e6  ( 0.00%) |  0.174  (99.4% /  0.6%) |    52.114
  4000 |   4000 |   16e6  ( 0.00%) |  0.283  (99.0% /  1.0%) |    57.061
  5000 |   5000 |   25e6  ( 0.00%) |  0.420  (99.2% /  0.8%) |    59.928
  6000 |   6000 |   36e6  ( 0.00%) |  0.626  (99.2% /  0.8%) |    57.932
  7000 |   7000 |   49e6  ( 0.00%) |  0.833  (99.1% /  0.9%) |    59.350
  8000 |   8000 |   64e6  ( 0.00%) |  1.058  (98.8% /  1.2%) |    61.259
  9000 |   9000 |   81e6  ( 0.00%) |  1.377  (99.2% /  0.8%) |    59.291
 10000 |  10000 |  100e6  ( 0.00%) |  1.696  (99.1% /  0.9%) |    59.507
 20000 |  20000 |  400e6  ( 0.00%) |  6.755  (99.1% /  0.9%) |    59.763
```

**Linux**
```
Anonlink benchmark -- see README for explanation
------------------------------------------------

Threshold: 0.5
Size 1 | Size 2 | Comparisons      | Total Time (s)          | Throughput
       |        |        (match %) | (comparisons / matching)|  (1e6 cmp/s)
-------+--------+------------------+-------------------------+-------------
  1000 |   1000 |    1e6  ( 0.00%) |  1.197  (52.2% / 47.8%) |     1.601
  2000 |   2000 |    4e6  ( 0.00%) |  5.230  (47.2% / 52.8%) |     1.620
  3000 |   3000 |    9e6  ( 0.00%) | 15.155  (42.5% / 57.5%) |     1.399
  4000 |   4000 |   16e6  ( 0.00%) | 55.438  (65.1% / 34.9%) |     0.444

Threshold: 0.7
Size 1 | Size 2 | Comparisons      | Total Time (s)          | Throughput
       |        |        (match %) | (comparisons / matching)|  (1e6 cmp/s)
-------+--------+------------------+-------------------------+-------------
  1000 |   1000 |    1e6  ( 0.00%) |  0.017  (98.7% /  1.3%) |    58.244
  2000 |   2000 |    4e6  ( 0.00%) |  0.051  (99.2% /  0.8%) |    78.589
  3000 |   3000 |    9e6  ( 0.00%) |  0.103  (99.2% /  0.8%) |    88.180
  4000 |   4000 |   16e6  ( 0.00%) |  0.177  (99.2% /  0.8%) |    90.987
  5000 |   5000 |   25e6  ( 0.00%) |  0.262  (99.0% /  1.0%) |    96.208
  6000 |   6000 |   36e6  ( 0.00%) |  0.396  (98.9% /  1.1%) |    91.916
  7000 |   7000 |   49e6  ( 0.00%) |  0.606  (99.1% /  0.9%) |    81.576
  8000 |   8000 |   64e6  ( 0.00%) |  0.651  (99.1% /  0.9%) |    99.271
  9000 |   9000 |   81e6  ( 0.00%) |  0.831  (98.7% /  1.3%) |    98.701
 10000 |  10000 |  100e6  ( 0.00%) |  1.067  (98.8% /  1.2%) |    94.876
 20000 |  20000 |  400e6  ( 0.00%) |  4.191  (98.9% /  1.1%) |    96.514
```

