### PR TITLE
Use bitarray fork

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@
 
 - Adds support for Windows including accelerated extensions. Note performance on Windows is
   roughly half that of Linux.
+- Switch to using a fork of `bitarray` that distributes binary wheels.
+
 
 0.12.5
 ======

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-bitarray==1.0.1
+bitarray-hardbyte==1.1.0
 cffi>=1.7
 clkhash>=0.11
 Cython==0.29.10
 hypothesis==4.33.0
 pytest>=3.4
 pytest-cov>=2.5
-bitarray-hardbyte==1.1.0
 numpy==1.16.4
 mypy-extensions==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bitarray==1.0.1
 cffi>=1.7
 pytest>=3.4
 pytest-cov>=2.5
-clkhash==0.13.0
+bitarray-hardbyte==1.1.0
 numpy==1.16.4
 mypy-extensions==0.4.1
 hypothesis==4.33.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 bitarray==1.0.1
 cffi>=1.7
+clkhash>=0.11
+Cython==0.29.10
+hypothesis==4.33.0
 pytest>=3.4
 pytest-cov>=2.5
 bitarray-hardbyte==1.1.0
 numpy==1.16.4
 mypy-extensions==0.4.1
-hypothesis==4.33.0
-Cython==0.29.10

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ else:
 here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = [
-        "bitarray>=0.8.1",
+        "bitarray-hardbyte>=0.8.0",
         "cffi>=1.7",
         "clkhash>=0.11",
         "numpy>=1.14",


### PR DESCRIPTION
Same as https://github.com/data61/clkhash/pull/308 switch to using a fork of bitarray that distributes binary wheels for easier installation (e.g. on Windows where having a compiler setup isn't guaranteed)