### PR TITLE
CI Update

### DIFF
--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -1,11 +1,10 @@
 
 steps:
 - bash: |
-    python -m pip install -U wheel
+    python -m pip install -U wheel==0.34.1
     # See https://github.com/joerick/cibuildwheel/pull/220
-    # for discussion on MacOS x64 builds
-    #python -m pip install cibuildwheel==1.1.0
-    python -m pip install git+https://github.com/joerick/cibuildwheel
+    # for discussion on supporting MacOS x64 builds
+    python -m pip install git+https://github.com/joerick/cibuildwheel@b779a88fde08aa85dd2e86dea536b70dfcad913c
     cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
   displayName: Build Wheel

--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -2,10 +2,12 @@
 steps:
 - task: UsePythonVersion@0
 - bash: |
-    # Use this fork of cibuildwheel for macos c++11 support
+    # See
     # https://github.com/joerick/cibuildwheel/pull/156
-    # python -m pip install git+https://github.com/Czaki/cibuildwheel
-    python -m pip install cibuildwheel==0.12.0
+    # for discussion on MacOS c++11 support
+    python -m pip install wheel==0.34.1
+    #python -m pip install cibuildwheel==1.1.0
+    python -m pip install git+https://github.com/joerick/cibuildwheel
     cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
   displayName: Build Wheel

--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -1,11 +1,9 @@
 
 steps:
-- task: UsePythonVersion@0
 - bash: |
-    # See
-    # https://github.com/joerick/cibuildwheel/pull/156
-    # for discussion on MacOS c++11 support
-    python -m pip install wheel==0.34.1
+    python -m pip install -U wheel
+    # See https://github.com/joerick/cibuildwheel/pull/220
+    # for discussion on MacOS x64 builds
     #python -m pip install cibuildwheel==1.1.0
     python -m pip install git+https://github.com/joerick/cibuildwheel
     cibuildwheel --print-build-identifiers

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ cache:
 python:
 - 3.6
 - 3.7
-- 3.8-dev
+- 3.8
+- 3.9-dev
 - nightly
 - pypy3
 
@@ -28,7 +29,7 @@ script:
 jobs:
   fast_finish: true
   allow_failures:
-    - python: "3.8-dev"
+    - python: "3.9-dev"
     - python: "nightly"
     - python: "pypy3"
     - name: "Extended Size 100K"
@@ -45,13 +46,6 @@ jobs:
       python: "3.7"
       env:
         - INCLUDE_100K=1
-    - stage: test
-      name: "Typecheck"
-      python: "3.7"
-      before_install:
-        - travis_retry pip install -U mypy
-      script:
-        - mypy anonlink --ignore-missing-imports
     - stage: "Build wheels"
       name: "manylinux1_x86_64"
       sudo: required

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -25,21 +25,24 @@ stages:
     variables:
       CIBW_BUILD: 'cp38-*'
     steps:
-    - template: .azurePipeline/cibuildwheel_steps.yml
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
+      - template: .azurePipeline/cibuildwheel_steps.yml
   - job: linux_37
     displayName: Linux + Python3.7
     pool: {vmImage: 'Ubuntu-16.04'}
     variables:
       CIBW_BUILD: 'cp37-*'
     steps:
-    - template: .azurePipeline/cibuildwheel_steps.yml
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - template: .azurePipeline/cibuildwheel_steps.yml
   - job: linux_36
     displayName: Linux + Python3.6
     pool: {vmImage: 'Ubuntu-16.04'}
     variables:
       CIBW_BUILD: 'cp36-*'
     steps:
-    - template: .azurePipeline/cibuildwheel_steps.yml
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
+      - template: .azurePipeline/cibuildwheel_steps.yml
   - job: macos
     displayName: MacOS
     pool: {vmImage: 'macOS-10.14'}

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -14,7 +14,7 @@ stages:
     # Need to install development libraries for manylinux container
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel'
     # Only build for Python36+, and x64 arch
-    CIBW_BUILD: 'cp37-* cp36-*'
+    CIBW_BUILD: 'cp38-* cp37-* cp36-*'
     CIBW_SKIP: '*-win32 *-manylinux1_i686'
   jobs:
   - job: linux_37
@@ -35,7 +35,7 @@ stages:
     displayName: MacOS
     pool: {vmImage: 'macOS-10.14'}
     variables:
-      MACOSX_DEPLOYMENT_TARGET: '10.10'
+      MACOSX_DEPLOYMENT_TARGET: '10.14'
     steps:
     - template: .azurePipeline/cibuildwheel_steps.yml
   - job: windows

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -31,13 +31,13 @@ stages:
       CIBW_BUILD: 'cp36-*'
     steps:
     - template: .azurePipeline/cibuildwheel_steps.yml
-#  - job: macos
-#    displayName: MacOS
-#    pool: {vmImage: 'macOS-10.13'}
-#    variables:
-#      MACOSX_DEPLOYMENT_TARGET: '10.13'
-#    steps:
-#    - template: .azurePipeline/cibuildwheel_steps.yml
+  - job: macos
+    displayName: MacOS
+    pool: {vmImage: 'macOS-10.13'}
+    variables:
+      MACOSX_DEPLOYMENT_TARGET: '10.10'
+    steps:
+    - template: .azurePipeline/cibuildwheel_steps.yml
   - job: windows
     displayName: Windows
     pool: {vmImage: 'vs2017-win2016'}

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -15,7 +15,9 @@ stages:
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel'
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp38-* cp37-* cp36-*'
-    CIBW_SKIP: '*-win32 *-manylinux1_i686 *macosx_intel'
+    # Add MacOS Python 3.6 and 3.7 on x64 once https://github.com/joerick/cibuildwheel/pull/220
+    # is merged/released.
+    CIBW_SKIP: '*-win32 *-manylinux_i686 *macosx_intel'
   jobs:
   - job: linux_38
     displayName: Linux + Python3.8
@@ -117,7 +119,7 @@ stages:
         Python3.8:
           pythonVersion: '3.8'
           artifactName: 'wheels.windows'
-          artifactPattern: '**/*cp38m*.whl'
+          artifactPattern: '**/*cp38*.whl'
     steps:
       - template: .azurePipeline/unittest_wheel_steps.yml
         parameters:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -33,7 +33,7 @@ stages:
     - template: .azurePipeline/cibuildwheel_steps.yml
   - job: macos
     displayName: MacOS
-    pool: {vmImage: 'macOS-10.13'}
+    pool: {vmImage: 'macOS-10.14'}
     variables:
       MACOSX_DEPLOYMENT_TARGET: '10.10'
     steps:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -15,7 +15,7 @@ stages:
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel'
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp38-* cp37-* cp36-*'
-    CIBW_SKIP: '*-win32 *-manylinux1_i686'
+    CIBW_SKIP: '*-win32 *-manylinux1_i686 *macosx_intel'
   jobs:
   - job: linux_37
     displayName: Linux + Python3.7

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -17,6 +17,13 @@ stages:
     CIBW_BUILD: 'cp38-* cp37-* cp36-*'
     CIBW_SKIP: '*-win32 *-manylinux1_i686 *macosx_intel'
   jobs:
+  - job: linux_38
+    displayName: Linux + Python3.8
+    pool: {vmImage: 'Ubuntu-16.04'}
+    variables:
+      CIBW_BUILD: 'cp38-*'
+    steps:
+    - template: .azurePipeline/cibuildwheel_steps.yml
   - job: linux_37
     displayName: Linux + Python3.7
     pool: {vmImage: 'Ubuntu-16.04'}
@@ -44,6 +51,7 @@ stages:
     steps:
       - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
       - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
       - template: .azurePipeline/cibuildwheel_steps.yml
 
 - stage: test
@@ -62,33 +70,36 @@ stages:
         Python3.7:
           pythonVersion: '3.7'
           artifactName: 'wheels.linux37'
+        Python3.8:
+          pythonVersion: '3.8'
+          artifactName: 'wheels.linux38'
     steps:
       - template: .azurePipeline/unittest_wheel_steps.yml
         parameters:
           artifactName: $(artifactName)
           pythonVersion: $(pythonVersion)
           operatingSystem: 'ubuntu-16.04'
-#  - job:
-#    displayName: MacOS
-#    pool:
-#      vmImage: 'macOS-10.13'
-#    strategy:
-#      matrix:
-#        Python3.6:
-#          pythonVersion: '3.6'
-#          artifactName: 'wheels.macos'
-#          artifactPattern: '**/*cp36*.whl'
-#        Python3.7:
-#          pythonVersion: '3.7'
-#          artifactName: 'wheels.macos'
-#          artifactPattern: '**/*cp37*.whl'
-#    steps:
-#      - template: .azurePipeline/unittest_wheel_steps.yml
-#        parameters:
-#          artifactName: $(artifactName)
-#          artifactPattern: $(artifactPattern)
-#          pythonVersion: $(pythonVersion)
-#          operatingSystem: 'macOS-10.13'
+  - job:
+    displayName: MacOS
+    pool:
+      vmImage: 'macOS-10.14'
+    strategy:
+      matrix:
+        Python3.7:
+          pythonVersion: '3.7'
+          artifactName: 'wheels.macos'
+          artifactPattern: '**/*cp37*.whl'
+        Python3.8:
+          pythonVersion: '3.8'
+          artifactName: 'wheels.macos'
+          artifactPattern: '**/*cp38*.whl'
+    steps:
+      - template: .azurePipeline/unittest_wheel_steps.yml
+        parameters:
+          artifactName: $(artifactName)
+          artifactPattern: $(artifactPattern)
+          pythonVersion: $(pythonVersion)
+          operatingSystem: 'macOS-10.14'
   - job:
     displayName: Windows
     pool:
@@ -103,6 +114,10 @@ stages:
           pythonVersion: '3.7'
           artifactName: 'wheels.windows'
           artifactPattern: '**/*cp37m*.whl'
+        Python3.8:
+          pythonVersion: '3.8'
+          artifactName: 'wheels.windows'
+          artifactPattern: '**/*cp38m*.whl'
     steps:
       - template: .azurePipeline/unittest_wheel_steps.yml
         parameters:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -87,10 +87,11 @@ stages:
       vmImage: 'macOS-10.14'
     strategy:
       matrix:
-        Python3.7:
-          pythonVersion: '3.7'
-          artifactName: 'wheels.macos'
-          artifactPattern: '**/*cp37*.whl'
+# Uncomment once wheels build on Python3.7 x64
+#        Python3.7:
+#          pythonVersion: '3.7'
+#          artifactName: 'wheels.macos'
+#          artifactPattern: '**/*cp37*.whl'
         Python3.8:
           pythonVersion: '3.8'
           artifactName: 'wheels.macos'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bitarray-hardbyte==1.1.0
 cffi>=1.7
 clkhash==0.15.0
-Cython==0.29.10
+Cython==0.29.14
 hypothesis==4.33.0
 pytest>=3.4
 pytest-cov>=2.5

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
         "cffi>=1.7",
         "clkhash~=0.15.0",
         "numpy>=1.14",
-        "mypy-extensions>=0.3",
+        "mypy-extensions>=0.4",
         "Cython>=0.29.10"
     ]
 

--- a/tests/test_candidate_generation.py
+++ b/tests/test_candidate_generation.py
@@ -51,13 +51,13 @@ def test_no_blocking_three_datasets(k_):
     sims, (dset_is0, dset_is1), (rec_is0, rec_is1) = find_candidate_pairs(
         datasets, similarity_f, THRESHOLD, k=k_)
 
-    if k_ is 0:
+    if k_ == 0:
         assert list(sims) == []
         assert list(dset_is0) == []
         assert list(dset_is1) == []
         assert list(rec_is0) == []
         assert list(rec_is1) == []
-    elif k_ is 1:
+    elif k_ == 1:
         assert list(sims) == [0.9962946784347061,
                               0.9432949307428928,
                               0.900267827898046,


### PR DESCRIPTION
This PR fixes the travis CI - the [master](https://travis-ci.org/data61/anonlink/builds/643542464?utm_medium=notification&utm_source=github_status) branch is failing. As we do `mypy` checks on Azure now rather than fix the static test job I've simply removed the duplication.

Additionally the PR goes *someway* to bringing back support for building macOS binary wheels using `cibuildwheel`. The short version is that wheels build fine for Python 3.8 but nothing else. The issue is the toolchain is setup to build both 32 and 64 bit variants even though we are okay only supporting 64bit arch. In any case upstream is close to merging a fix - see https://github.com/joerick/cibuildwheel/pull/220

Microsoft recently announced they are removing the `macOS-10.13` image so I've also updated that to 10.14:

> On March 23, 2020, we’ll be removing the following Azure Pipelines hosted images
> ...
> We have decided to remove the macOS-10.13 image because less than 5% of users use macOS High Sierra 10.13 and there is a later macOS version image – macOS-10.14 available. In addition, we will be adding the latest macOS version – Catalina or macOS-10.15 on February 3, 2020.

Finally, since I introduced building for Python3.8 for MacOS I also added support on Windows and Linux.