### PR TITLE
pining requirements to specific versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 bitarray-hardbyte==1.2.2
-cffi>=1.7
+cffi==1.14.0
 clkhash==0.15.2
 Cython==0.29.16
 hypothesis==5.10.4
-pytest>=3.4
-pytest-cov>=2.5
+pytest==5.4.3
+pytest-cov==2.10.0
 numpy==1.18.2
 mypy-extensions==0.4.3


### PR DESCRIPTION
in order to make the environment easily reproducible

Also, travis cannot install dependencies, as pytest-cov takes offense on the too old pytest version