### PR TITLE
building wheels for mac

### DIFF
--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -1,10 +1,13 @@
 
 steps:
 - bash: |
-    python -m pip install -U wheel==0.34.1
+    python3 -m pip install --upgrade pip
+    pip3 install cibuildwheel==1.4.2
+
+    #python -m pip install -U wheel==0.34.1
     # See https://github.com/joerick/cibuildwheel/pull/220
     # for discussion on supporting MacOS x64 builds
-    python -m pip install git+https://github.com/joerick/cibuildwheel@b779a88fde08aa85dd2e86dea536b70dfcad913c
+    #python -m pip install git+https://github.com/joerick/cibuildwheel@b779a88fde08aa85dd2e86dea536b70dfcad913c
     cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
   displayName: Build Wheel

--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -3,11 +3,6 @@ steps:
 - bash: |
     python3 -m pip install --upgrade pip
     pip3 install cibuildwheel==1.4.2
-
-    #python -m pip install -U wheel==0.34.1
-    # See https://github.com/joerick/cibuildwheel/pull/220
-    # for discussion on supporting MacOS x64 builds
-    #python -m pip install git+https://github.com/joerick/cibuildwheel@b779a88fde08aa85dd2e86dea536b70dfcad913c
     cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
   displayName: Build Wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -15,9 +15,7 @@ stages:
     CIBW_BEFORE_BUILD_LINUX: 'yum install -y libffi-devel atlas-devel'
     # Only build for Python36+, and x64 arch
     CIBW_BUILD: 'cp38-* cp37-* cp36-*'
-    # Add MacOS Python 3.6 and 3.7 on x64 once https://github.com/joerick/cibuildwheel/pull/220
-    # is merged/released.
-    CIBW_SKIP: '*-win32 *-manylinux_i686 *macosx_intel'
+    CIBW_SKIP: '*-win32 *-manylinux_i686'
   jobs:
   - job: linux_38
     displayName: Linux + Python3.8
@@ -49,7 +47,10 @@ stages:
     variables:
       MACOSX_DEPLOYMENT_TARGET: '10.14'
     steps:
-    - template: .azurePipeline/cibuildwheel_steps.yml
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+      - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
+      - template: .azurePipeline/cibuildwheel_steps.yml
   - job: windows
     displayName: Windows
     pool: {vmImage: 'vs2017-win2016'}
@@ -90,11 +91,10 @@ stages:
       vmImage: 'macOS-10.14'
     strategy:
       matrix:
-# Uncomment once wheels build on Python3.7 x64
-#        Python3.7:
-#          pythonVersion: '3.7'
-#          artifactName: 'wheels.macos'
-#          artifactPattern: '**/*cp37*.whl'
+        Python3.7:
+          pythonVersion: '3.7'
+          artifactName: 'wheels.macos'
+          artifactPattern: '**/*cp37*.whl'
         Python3.8:
           pythonVersion: '3.8'
           artifactName: 'wheels.macos'


### PR DESCRIPTION
because of problems with cibuildwheel we only created a wheel for mac with python3.8.
There is a new version of cibuildwheel out, and now we can build again for all python3 versions. Yay!

Also re-enabled unit testing for mac with python3.7