### PR TITLE
Feature arbitrary size encodings

### DIFF
--- a/anonlink/similarities/_dice.pyx
+++ b/anonlink/similarities/_dice.pyx
@@ -43,7 +43,6 @@ def popcount_arrays_preallocated_output(
     """
     :param input_data: flattened contiguous char input of ARRAY_BYTES elements
     """
-    #assert array_bytes % 8 == 0
     cdef double elapsed_time
 
     # Create a memoryview of the input data and preallocated count results
@@ -170,9 +169,6 @@ def dice_many_to_many(
         )
         total_matches += matches
         i_buffer_memview[:] = i
-
-        if matches < 0:
-            raise RuntimeError('bad key length')
 
         assert matches <= k
         result_sims.extend(c_scores[:matches])

--- a/anonlink/similarities/_dice.pyx
+++ b/anonlink/similarities/_dice.pyx
@@ -23,6 +23,11 @@ cpdef unsigned int[::1] popcount_arrays(const char[::1] input_data, unsigned int
         output_size = len(input_data) // array_bytes
     # The CPP code reasonably assumes the length of the data is evenly divided by the array_bytes
     assert len(input_data) % array_bytes == 0, "input data length not divisible by array_bytes"
+
+    # To permit arbitrary size input_data, we may need to pad with zeros to align to a word boundary?
+    # Eg say our input is 32 bits and our array size is 8, our output_size is already correct at 4
+    # but we may want to make the input 64 bits?
+
     output_counts = array.clone(unsigned_int_array_template, output_size, zero=True)
     popcount_arrays_preallocated_output(output_counts, input_data, array_bytes)
     return output_counts
@@ -38,7 +43,7 @@ def popcount_arrays_preallocated_output(
     """
     :param input_data: flattened contiguous char input of ARRAY_BYTES elements
     """
-    assert array_bytes % 8 == 0
+    #assert array_bytes % 8 == 0
     cdef double elapsed_time
 
     # Create a memoryview of the input data and preallocated count results

--- a/anonlink/similarities/_dice_x86.py
+++ b/anonlink/similarities/_dice_x86.py
@@ -26,10 +26,11 @@ def dice_coefficient_accelerated(
 ) -> Tuple[FloatArrayType, Tuple[IntArrayType, ...]]:
     """Find Dice coefficients of CLKs.
 
-    This version uses x86 popcount instructions.
+    This version uses a CPP implementation which will take advantage of
+    native x86 popcount instructions.
 
     We assume all filters are the same length and that this length is a
-    multiple of 64 bits.
+    multiple of 8 bits.
 
     The returned pairs are sorted in decreasing order of similarity,
     then in increasing order of the record index in the first dataset,
@@ -43,7 +44,12 @@ def dice_coefficient_accelerated(
     :param k: Only permit this many candidate pairs per dataset pair
         per record. Set to `None` to permit all pairs above with
         similarity at least `threshold`.
-    
+
+    :raises NotImplementedError: If an unsupported length filter is
+        provided.
+
+    :raises ValueError: If different filter lengths are provided.
+
     :return: A 2-tuple of similarity scores and indices. The similarity
         scores are an array of floating-point values. The indices are a
         2-tuple of arrays of integers.

--- a/anonlink/similarities/_dice_x86.py
+++ b/anonlink/similarities/_dice_x86.py
@@ -78,8 +78,8 @@ def dice_coefficient_accelerated(
     if not _all_equal(map(len, chain(filters0, filters1))):
         raise ValueError('inconsistent filter length')
     filter_bits = len(filters0[0])
-    if filter_bits % 64:
-        msg = (f'only filters whose length in bits is a multiple of 64 '
+    if filter_bits % 8:
+        msg = (f'only filters whose length in bits is a multiple of 8 '
                f'are currently supported (got filter with length '
                f'{filter_bits})')
         raise NotImplementedError(msg)

--- a/anonlink/similarities/dice.cpp
+++ b/anonlink/similarities/dice.cpp
@@ -176,6 +176,26 @@ _popcount_array(const uint64_t *array, int nwords) {
 
 /**
  * The popcount of the logical AND of n corresponding elements of buf1
+ * and buf2 is returned. The AND of the two input buffers is placed
+ * in buf1n2.
+ * Byte version, see below for word aligned version.
+ */
+static inline uint64_t
+popcount_logand_chars(
+        char *buf1n2,
+        const char *buf1,
+        const char *buf2,
+        int n
+        ) {
+    for (int i = 0; i < n; i++) {
+        buf1n2[i] = buf1[i] & buf2[i];
+    }
+    return popcnt(&buf1n2[0], n);
+}
+
+
+/**
+ * The popcount of the logical AND of n corresponding elements of buf1
  * and buf2 is the sum of c0, c1, c2, c3.
  */
 template<int n>
@@ -261,6 +281,22 @@ _popcount_logand_array(const uint64_t *u, const uint64_t *v, int len) {
 }
 
 /**
+ * Return the Sorensen-Dice coefficient of n byte length arrays u and
+ * v, whose popcounts are given in u_popc and v_popc respectively.
+ *
+ * Byte version
+ */
+static inline double
+_dice_coeff_chars(
+        const char *u, uint32_t u_popc,
+        const char *v, uint32_t v_popc,
+        char *andbuffer,
+        int n) {
+    uint64_t uv_popc = popcount_logand_chars(andbuffer, u, v, n);
+    return (2 * uv_popc) / (double) (u_popc + v_popc);
+}
+
+/**
  * Return the Sorensen-Dice coefficient of nwords length arrays u and
  * v, whose popcounts are given in u_popc and v_popc respectively.
  */
@@ -269,6 +305,7 @@ _dice_coeff_generic(
         const uint64_t *u, uint32_t u_popc,
         const uint64_t *v, uint32_t v_popc,
         int nwords) {
+
     uint32_t uv_popc = _popcount_logand_array(u, v, nwords);
     return (2 * uv_popc) / (double) (u_popc + v_popc);
 }
@@ -414,22 +451,29 @@ extern "C"
     popcount_arrays(
             uint32_t *counts,
             const char *arrays, int narrays, int array_bytes) {
-        // assumes WORD_BYTES divides array_bytes
-        int nwords = array_bytes / WORD_BYTES;
-        // The static_cast is to avoid int overflow in the multiplication
-        size_t total_bytes = static_cast<size_t>(narrays) * array_bytes;
-        auto ptr = adjust_ptr_alignment(arrays, total_bytes);
-        auto u = ptr.get();
-
         clock_t t = clock();
-        switch (nwords) {
-        case 64: _popcount_arrays<64>(counts, u, narrays); break;
-        case 32: _popcount_arrays<32>(counts, u, narrays); break;
-        case 16: _popcount_arrays<16>(counts, u, narrays); break;
-        case  8: _popcount_arrays< 8>(counts, u, narrays); break;
-        default:
-            for (int i = 0; i < narrays; ++i, u += nwords)
-                counts[i] = _popcount_array(u, nwords);
+        if (array_bytes >= WORD_BYTES && array_bytes % WORD_BYTES == 0) {
+            // WORD_BYTES divides array_bytes
+            int nwords = array_bytes / WORD_BYTES;
+            // The static_cast is to avoid int overflow in the multiplication
+            size_t total_bytes = static_cast<size_t>(narrays) * array_bytes;
+            auto ptr = adjust_ptr_alignment(arrays, total_bytes);
+            auto u = ptr.get();
+
+            switch (nwords) {
+            case 64: _popcount_arrays<64>(counts, u, narrays); break;
+            case 32: _popcount_arrays<32>(counts, u, narrays); break;
+            case 16: _popcount_arrays<16>(counts, u, narrays); break;
+            case  8: _popcount_arrays< 8>(counts, u, narrays); break;
+            default:
+                for (int i = 0; i < narrays; ++i, u += nwords)
+                    counts[i] = _popcount_array(u, nwords);
+            }
+        } else {
+            // array_bytes not aligned with our word size
+            for (int i = 0; i < narrays; ++i) {
+                counts[i] = popcnt(&arrays[i], array_bytes);
+            }
         }
         return to_millis(clock() - t);
     }
@@ -483,15 +527,7 @@ extern "C"
             unsigned int *indices,
             double *scores) {
 
-        if (keybytes % WORD_BYTES != 0)
-            return -1;
-        int keywords = keybytes / WORD_BYTES;
-        // The static_cast is to avoid int overflow in the multiplication
-        size_t total_bytes = static_cast<size_t>(n) * keybytes;
-        auto ptr_comp1 = adjust_ptr_alignment(one, total_bytes);
-        auto ptr_comp2 = adjust_ptr_alignment(many, total_bytes);
-        auto comp1 = ptr_comp1.get();
-        auto comp2 = ptr_comp2.get();
+        uint32_t count_one;
 
         // Here we create top_k_scores on the stack by providing it
         // with a vector in which to put its elements. We do this so
@@ -506,61 +542,121 @@ extern "C"
         Node temp_node;
         vec.reserve(k + 1);
         node_queue top_k_scores(score_cmp(), vec);
+        bool key_is_word_divisible = (keybytes > WORD_BYTES) && (keybytes % WORD_BYTES == 0);
+        if (key_is_word_divisible) {
+            // keybytes is divisible by WORD_BYTES
+            int keywords = keybytes / WORD_BYTES;
+            // The static_cast is to avoid int overflow in the multiplication
+            size_t total_bytes = static_cast<size_t>(n) * keybytes;
+            auto ptr_comp1 = adjust_ptr_alignment(one, total_bytes);
+            auto ptr_comp2 = adjust_ptr_alignment(many, total_bytes);
+            auto comp1 = ptr_comp1.get();
+            auto comp2 = ptr_comp2.get();
 
-        uint32_t count_one = _popcount_array(comp1, keywords);
-        if (count_one == 0) {
-            if (threshold > 0) {
-                return 0;
+            count_one = _popcount_array(comp1, keywords);
+
+            if (count_one == 0) {
+                if (threshold > 0) {
+                    return 0;
+                }
+
+                for (uint32_t j = 0; j < k; ++j) {
+                    scores[j] = 0.0;
+                    indices[j] = j;
+                }
+
+                return static_cast<int>(k);
             }
 
-            for (uint32_t j = 0; j < k; ++j) {
-                scores[j] = 0.0;
-                indices[j] = j;
+            uint32_t max_popcnt_delta = keybytes * CHAR_BIT; // = bits per key
+            if(threshold > 0) {
+                max_popcnt_delta = calculate_max_difference(count_one, threshold);
             }
 
-            return static_cast<int>(k);
-        }
+            double dynamic_threshold = threshold;
+            auto push_score = [&](double score, int idx) {
+                if (score >= dynamic_threshold) {
+                    top_k_scores.push(Node(idx, score));
+                    if (top_k_scores.size() > k) {
+                        // Popping the top element is O(log(k))!
+                        temp_node = top_k_scores.top();
+                        top_k_scores.pop();
+                        // threshold can now be raised
+                        dynamic_threshold = temp_node.score;
+                    }
+                }
+            };
 
-        uint32_t max_popcnt_delta = keybytes * CHAR_BIT; // = bits per key
-        if(threshold > 0) {
-            max_popcnt_delta = calculate_max_difference(count_one, threshold);
-        }
-
-        double dynamic_threshold = threshold;
-        auto push_score = [&](double score, int idx) {
-            if (score >= dynamic_threshold) {
-                top_k_scores.push(Node(idx, score));
-                if (top_k_scores.size() > k) {
-                    // Popping the top element is O(log(k))!
-                    temp_node = top_k_scores.top();
-                    top_k_scores.pop();
-                    // threshold can now be raised
-                    dynamic_threshold = temp_node.score;
+            const uint64_t *current = comp2;
+            // NB: For any key length that must run at maximum speed, we
+            // need to specialise a block in the following 'if' statement
+            // (which is an example of specialising to keywords == 16).
+            if (keywords == 16) {
+                for (int j = 0; j < n; j++, current += 16) {
+                    const uint32_t counts_many_j = counts_many[j];
+                    if (abs_diff(count_one, counts_many_j) <= max_popcnt_delta) {
+                        double score = _dice_coeff<16>(comp1, count_one, current, counts_many_j);
+                        push_score(score, j);
+                    }
+                }
+            } else {
+                for (int j = 0; j < n; j++, current += keywords) {
+                    const uint32_t counts_many_j = counts_many[j];
+                    if (abs_diff(count_one, counts_many_j) <= max_popcnt_delta) {
+                        double score = _dice_coeff_generic(comp1, count_one, current, counts_many_j, keywords);
+                        push_score(score, j);
+                    }
                 }
             }
-        };
 
-        const uint64_t *current = comp2;
-
-        // NB: For any key length that must run at maximum speed, we
-        // need to specialise a block in the following 'if' statement
-        // (which is an example of specialising to keywords == 16).
-        if (keywords == 16) {
-            for (int j = 0; j < n; j++, current += 16) {
-                const uint32_t counts_many_j = counts_many[j];
-                if (abs_diff(count_one, counts_many_j) <= max_popcnt_delta) {
-                    double score = _dice_coeff<16>(comp1, count_one, current, counts_many_j);
-                    push_score(score, j);
-                }
-            }
         } else {
-            for (int j = 0; j < n; j++, current += keywords) {
+            // As the keybytes is not evenly divisible by WORD_BYTES we
+            // process individual bytes instead of 64 bit words.
+            count_one = popcnt(one, keybytes);
+
+            // DUPLICATED FROM ABOVE
+            if (count_one == 0) {
+                if (threshold > 0) {
+                    return 0;
+                }
+
+                for (uint32_t j = 0; j < k; ++j) {
+                    scores[j] = 0.0;
+                    indices[j] = j;
+                }
+
+                return static_cast<int>(k);
+            }
+            uint32_t max_popcnt_delta = keybytes * CHAR_BIT; // = bits per key
+            if(threshold > 0) {
+                max_popcnt_delta = calculate_max_difference(count_one, threshold);
+            }
+            double dynamic_threshold = threshold;
+            auto push_score = [&](double score, int idx) {
+                if (score >= dynamic_threshold) {
+                    top_k_scores.push(Node(idx, score));
+                    if (top_k_scores.size() > k) {
+                        // Popping the top element is O(log(k))!
+                        temp_node = top_k_scores.top();
+                        top_k_scores.pop();
+                        // threshold can now be raised
+                        dynamic_threshold = temp_node.score;
+                    }
+                }
+            };
+
+            const char *current = many;
+            char *andbuffer = new char[keybytes];
+
+            for (int j = 0; j < n; j++, current += keybytes) {
                 const uint32_t counts_many_j = counts_many[j];
                 if (abs_diff(count_one, counts_many_j) <= max_popcnt_delta) {
-                    double score = _dice_coeff_generic(comp1, count_one, current, counts_many_j, keywords);
+                    double score = _dice_coeff_chars(one, count_one, current, counts_many_j, andbuffer, keybytes);
                     push_score(score, j);
                 }
             }
+            delete andbuffer;
+
         }
 
         // Copy the scores and indices in reverse order so that the

--- a/anonlink/similarities/dice.cpp
+++ b/anonlink/similarities/dice.cpp
@@ -305,7 +305,6 @@ _dice_coeff_generic(
         const uint64_t *u, uint32_t u_popc,
         const uint64_t *v, uint32_t v_popc,
         int nwords) {
-
     uint32_t uv_popc = _popcount_logand_array(u, v, nwords);
     return (2 * uv_popc) / (double) (u_popc + v_popc);
 }
@@ -513,8 +512,7 @@ extern "C"
 
     /**
      * Calculate up to the top k indices and scores.  Returns the
-     * number matched above the given threshold or -1 if keybytes is
-     * not a multiple of 8.
+     * number matched above the given threshold
      */
     int match_one_against_many_dice_k_top(
             const char *one,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bitarray-hardbyte==1.6.1
 clkhash==0.16.0
 Cython==0.29.21
-hypothesis==5.38.1
+hypothesis==5.41.0
 pytest==6.1.2
 pytest-cov==2.10.1
 numpy==1.19.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bitarray-hardbyte==1.6.1
 clkhash==0.16.0
 Cython==0.29.21
-hypothesis==5.41.0
+hypothesis==5.41.1
 pytest==6.1.2
 pytest-cov==2.10.1
 numpy==1.19.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ bitarray-hardbyte==1.6.1
 clkhash==0.16.0
 Cython==0.29.21
 hypothesis==5.38.1
-pytest==6.1.1
+pytest==6.1.2
 pytest-cov==2.10.1
 numpy==1.19.3
 mypy-extensions==0.4.3

--- a/tests/test_popcount.py
+++ b/tests/test_popcount.py
@@ -12,44 +12,42 @@ from hypothesis.strategies import composite
 def aligned_bytes(draw, num_words=None):
     if num_words is None:
         num_words = draw(integers(min_value=1, max_value=2048))
-    num_bytes = num_words * 8
+    num_bytes = num_words
     return draw(binary(min_size=num_bytes, max_size=num_bytes))
 
 
 @given(data())
-@pytest.mark.parametrize('num_bytes', [8, 32, 64, 512, 1024])
+@pytest.mark.parametrize('num_bytes', [8, 32, 64, 512, 1024, 2048])
 def test_popcnt_array(num_bytes, data):
     input_as_bitarray = bitarray()
     input_as_bytes = data.draw(binary(min_size=num_bytes, max_size=num_bytes))
     input_as_bitarray.frombytes(input_as_bytes)
     carr = array.array('b', input_as_bytes)
-    for array_size in [8, 16, 32, 64, 128, 256, 512]:
-        if array_size < num_bytes:
-            assert sum(_dice.popcount_arrays(carr, array_size)) == input_as_bitarray.count()
-    assert sum(_dice.popcount_arrays(carr, num_bytes)) == input_as_bitarray.count()
+    bitarray_count = input_as_bitarray.count()
+    for array_size in [8, 16, 32, 64, 128, 256, 512, 1024]:
+        if array_size <= num_bytes:
+            output_counts = _dice.popcount_arrays(carr, array_size)
+            assert output_counts[0] == input_as_bitarray[:array_size*8].count()
+            assert sum(output_counts) == bitarray_count
 
 
-@pytest.mark.parametrize('num_bytes', [2**i for i in range(12, 26)])
+@pytest.mark.parametrize('num_bytes', [2**i for i in range(10, 22)])
 def test_popcnt_large(num_bytes):
     data = bitarray("10101010" * num_bytes)
     carr = array.array('b', data.tobytes())
-    # Use an element size of 1024
+    # Use an element size of 1024 bytes
     output_counts = _dice.popcount_arrays(carr, 1024)
     assert output_counts[0] == data[:1024*8].count()
     assert output_counts[-1] == data[-1024*8:].count()
     assert sum(output_counts) == data.count()
 
-    for array_size in [2048, 4096, 8192]:
+    for array_size in [8, 4096, 8192]:
         if array_size < num_bytes:
             assert sum(_dice.popcount_arrays(carr, array_size)) == data.count()
 
 
 @given(aligned_bytes())
 def test_popcnt_array_len_1(input_as_bytes):
-    """
-    The array_bytes is set to the length of the input
-    """
-
     carr = array.array('b', input_as_bytes)
     resulting_popcount_array = _dice.popcount_arrays(carr, len(input_as_bytes))
     assert len(resulting_popcount_array) == 1
@@ -61,6 +59,9 @@ def test_popcnt_array_len_1(input_as_bytes):
 
 def test_popcnt_empty_array():
     carr = array.array('b', b'')
+    resulting_popcount_array = _dice.popcount_arrays(carr, 8)
+    assert len(resulting_popcount_array) == 0
+    # shouldn't make a difference having a array_size of zero
     resulting_popcount_array = _dice.popcount_arrays(carr, 0)
     assert len(resulting_popcount_array) == 0
 
@@ -76,7 +77,16 @@ def test_data_not_multiple_of_element_size(num_bytes):
         assert sum(output_counts) == data.count()
 
 
-@pytest.mark.parametrize('num_bytes', [2**i for i in range(6, 20)])
+def test_data_length_not_multiple_of_64():
+    # 32 bits of data, array_size of 8 bits (1 byte)
+    data = bitarray("10101010" * 4)
+    carr = array.array('b', data.tobytes())
+    output_counts = _dice.popcount_arrays(carr, 1)
+    assert len(output_counts) == 4
+    assert sum(output_counts) == data.count()
+
+
+@pytest.mark.parametrize('num_bytes', [2**i for i in range(6, 12)])
 def test_popcnt_all_ones(num_bytes):
     data = bitarray("1" * 8 * num_bytes)
     carr = array.array('b', data.tobytes())
@@ -86,7 +96,10 @@ def test_popcnt_all_ones(num_bytes):
     assert sum(output_counts) == 8 * num_bytes
 
 
-# @pytest.mark.parametrize('sim_fun', SIM_FUNS)
-#     @pytest.mark.parametrize('k', [None, 0, 1])
-#     @pytest.mark.parametrize('threshold', [0., .5])
-#     def test_all_low(self, sim_fun, k, threshold):
+@pytest.mark.parametrize('num_bytes', [2**i for i in range(6, 12)])
+def test_popcnt_all_zeros(num_bytes):
+    data = bitarray("0" * 8 * num_bytes)
+    carr = array.array('b', data.tobytes())
+    output_counts = _dice.popcount_arrays(carr, 8)
+    assert sum(output_counts) == 0
+

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -212,7 +212,11 @@ class TestBloomFilterComparison:
         c_similarity = similarities.dice_coefficient_accelerated(datasets, threshold, k=k)
         self.assert_similarity_matrices_equal(py_similarity, c_similarity)
 
-
+    def test_not_multiple_of_8_raises(self,):
+        datasets = [[bitarray('010')],
+                    [bitarray('010')]]
+        with pytest.raises(NotImplementedError):
+            similarities.dice_coefficient_accelerated(datasets, threshold=self.default_threshold)
 
     @pytest.mark.parametrize('sim_fun', SIM_FUNS)
     @pytest.mark.parametrize('k', [None, 0, 1])

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -206,8 +206,13 @@ class TestBloomFilterComparison:
     def test_not_multiple_of_64(self, k, threshold, bytes_n):
         datasets = [[bitarray('01001011') * bytes_n],
                     [bitarray('01001011') * bytes_n]]
-        with pytest.raises(NotImplementedError):
-            similarities.dice_coefficient_accelerated(datasets, threshold, k=k)
+
+        py_similarity = similarities.dice_coefficient_python(
+            datasets, self.default_threshold, k)
+        c_similarity = similarities.dice_coefficient_accelerated(datasets, threshold, k=k)
+        self.assert_similarity_matrices_equal(py_similarity, c_similarity)
+
+
 
     @pytest.mark.parametrize('sim_fun', SIM_FUNS)
     @pytest.mark.parametrize('k', [None, 0, 1])
@@ -286,9 +291,8 @@ def _to_bitarray(bytes_):
 def test_bytes_bitarray_agree(sim_fun, data, threshold):
     bytes_length = data.draw(strategies.integers(
         min_value=0,
-        max_value=1024  # Let's not get too carried away...
+        max_value=4096  # Let's not get too carried away...
     ))
-    bytes_length *= 8  # TODO: remove this line when we deal with #163
     filters0_bytes = data.draw(strategies.lists(strategies.binary(
         min_size=bytes_length, max_size=bytes_length)))
     filters1_bytes = data.draw(strategies.lists(strategies.binary(


### PR DESCRIPTION
Builds on https://github.com/data61/anonlink/pull/363 as suggested by @nbgl  in #163 

Implements in C a path to _popcount_ and _dice one to many_ when the encoding size is not word aligned. This means you can finally work on encodings of just 1 byte or 13 bytes (if you are so inclined). 

I haven't done any benchmarking although I've expanded and added several tests.

