### PR TITLE
update cibuildwheel

### DIFF
--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -2,7 +2,7 @@
 steps:
 - bash: |
     python3 -m pip install --upgrade pip
-    pip3 install cibuildwheel==1.4.2
+    pip3 install cibuildwheel==1.7.1
     cibuildwheel --print-build-identifiers
     cibuildwheel --output-dir wheelhouse .
   displayName: Build Wheel


### PR DESCRIPTION
we had a somewhat old version of cibuildwheel, and it was playing up.
This now points to the current release.