### PR TITLE
Build sdist in CI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,14 @@
 new version
 ===========
 
-- Creates a cython wrapper for the similarity comparison C++ code and removes the cffi compiler.
+0.14.0
+======
+
+- test and release for Python 3.9 too #384
+- fix cibuildwheel #382
+Thanks Brian for the following two PRs. That's awesome!
+- Feature arbitrary (byte)-size encodings #366
+- Creates a cython wrapper for the similarity comparison C++ code and removes the cffi compiler. #363
 
 0.13.1
 ======

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
-recursive-include _cffi_build *
-
 # Remove CFFI files
 global-exclude __pycache__/*
 
@@ -7,5 +5,6 @@ global-exclude __pycache__/*
 global-include *.pyx
 global-include *.pxd
 include anonlink/solving/_multiparty_solving_inner.h
-include _cffi_build/libpopcount.h
+include anonlink/similarities/libpopcount.h
 include anonlink/_entitymatcher*
+include anonlink/similarities/dice.cpp

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -122,7 +122,7 @@ stages:
             path: $(Pipeline.Workspace)
 
         - script: |
-            pip install $(Pipeline.Workspace)/anonlink-*.tar.gz
+            pip install anonlink-*.tar.gz
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -1,3 +1,11 @@
+trigger:
+  branches:
+    include:
+      - '*'
+  tags:
+    include:
+      - v*
+
 stages:
 - stage: wheels
   displayName: Build Wheel Packages
@@ -66,6 +74,25 @@ stages:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.9', architecture: x64}}
         - template: .azurePipeline/cibuildwheel_steps.yml
+
+- stage: sdist
+  displayName: Build source distribution
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.9'
+    - script: |
+        python setup.py sdist
+      displayName: 'Artifact creation'
+    - task: CopyFiles@2
+      inputs:
+        targetFolder: 'sdist'
+    - task: PublishBuildArtifacts@1
+      inputs:
+        PathtoPublish: 'sdist'
+        ArtifactName: 'drop'
 
 - stage: test
   displayName: Unit tests
@@ -184,6 +211,7 @@ stages:
         inputs:
           artifactName: 'drop'
           patterns: '**/*.whl'
+                    '**/*.tar.gz'
           path: $(Pipeline.Workspace)
       - task: TwineAuthenticate@1
         inputs:
@@ -191,3 +219,4 @@ stages:
       - script: 'echo $(Build.Repository.Name)'
       - script: 'echo $(Build.SourceBranchName)'
       - script: 'twine upload -r $(artifactFeed) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/*.whl --skip-existing'
+      - script: 'twine upload -r $(artifactFeed) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/*.tar.gz --skip-existing'

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -121,9 +121,8 @@ stages:
             patterns: '**/*.tar.gz'
             path: $(Pipeline.Workspace)
 
-        - script:
-            'cd $(Pipeline.Workspace)'
-            'pip install anonlink-*.tar.gz'
+        - script: 'cd $(Pipeline.Workspace)'
+        - script: 'pip install anonlink-*.tar.gz'
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -121,9 +121,9 @@ stages:
             patterns: '**/*.tar.gz'
             path: $(Pipeline.Workspace)
 
-        - script: |
-            cd $(Pipeline.Workspace)
-            pip install anonlink-*.tar.gz
+        - script:
+            'cd $(Pipeline.Workspace)'
+            'pip install anonlink-*.tar.gz'
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -121,7 +121,7 @@ stages:
             patterns: '**/*.tar.gz'
             path: $(Pipeline.Workspace)
 
-        - script: pip install anonlink-0.14.0.tar.gz
+        - script: pip install $(Pipeline.Workspace)/anonlink-0.14.0.tar.gz
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -121,7 +121,7 @@ stages:
             patterns: '**/*.tar.gz'
             path: $(Pipeline.Workspace)
 
-        - script: pip install anonlink --no-index --no-binary anonlink -f $(Pipeline.Workspace)'
+        - script: pip install anonlink --no-index --no-binary anonlink -f file://$(Pipeline.Workspace)'
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -122,7 +122,7 @@ stages:
             path: $(Pipeline.Workspace)
 
         - script: |
-            pip install anonlink --no-index -f $(Pipeline.Workspace)
+            pip install $(Pipeline.Workspace)/anonlink-*.tar.gz
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -122,6 +122,7 @@ stages:
             path: $(Pipeline.Workspace)
 
         - script: |
+            cd $(Pipeline.Workspace)
             pip install anonlink-*.tar.gz
           displayName: 'Install anonlink sdist'
         - script: |

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -19,7 +19,7 @@ stages:
     - job: linux_39
       displayName: Linux + Python3.9
       pool:
-        vmImage: 'ubuntu-16.04'
+        vmImage: 'ubuntu-18.04'
       variables:
         CIBW_BUILD: 'cp39-*'
       steps:
@@ -28,7 +28,7 @@ stages:
     - job: linux_38
       displayName: Linux + Python3.8
       pool:
-        vmImage: 'ubuntu-16.04'
+        vmImage: 'ubuntu-18.04'
       variables:
         CIBW_BUILD: 'cp38-*'
       steps:
@@ -37,7 +37,7 @@ stages:
     - job: linux_37
       displayName: Linux + Python3.7
       pool:
-        vmImage: 'ubuntu-16.04'
+        vmImage: 'ubuntu-18.04'
       variables:
         CIBW_BUILD: 'cp37-*'
       steps:
@@ -46,7 +46,7 @@ stages:
     - job: linux_36
       displayName: Linux + Python3.6
       pool:
-        vmImage: 'ubuntu-16.04'
+        vmImage: 'ubuntu-18.04'
       variables:
         CIBW_BUILD: 'cp36-*'
       steps:
@@ -82,7 +82,7 @@ stages:
     - job: sdist
       displayName: build source distribution
       pool:
-        vmImage: 'ubuntu-16.04'
+        vmImage: 'ubuntu-18.04'
       steps:
         - task: UsePythonVersion@0
           inputs:
@@ -98,37 +98,6 @@ stages:
             PathtoPublish: 'sdist/dist'
             ArtifactName: 'drop'
 
-- stage: TestSdistOnWinX86
-  displayName: testing if sdist can be compiled
-  dependsOn: [sdist]
-  jobs:
-    - job: winx86
-      displayName: testing on WinX86
-      pool:
-        vmImage: 'vs2017-win2016'
-      steps:
-        - task: UsePythonVersion@0
-          inputs:
-            versionSpec: '3.9'
-            architecture: x86
-        - script: |
-            python -m pip install --upgrade pip
-            pip install -U pytest-azurepipelines -r requirements.txt
-          displayName: 'Install testing requirements'
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: 'drop'
-            patterns: '**/*.tar.gz'
-            path: $(Pipeline.Workspace)
-
-        - script: pip install $(Pipeline.Workspace)/anonlink-0.14.0.tar.gz
-          displayName: 'Install anonlink sdist'
-        - script: |
-            # Delete the source code folder to ensure we test only the installed wheel
-            rm -fr anonlink
-            pytest -W ignore::DeprecationWarning
-          displayName: 'pytest'
-
 - stage: test
   displayName: Unit tests
   dependsOn: ['wheels']
@@ -136,7 +105,7 @@ stages:
   - job:
     displayName: Linux
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     strategy:
       matrix:
         Python3.6:
@@ -156,7 +125,7 @@ stages:
         parameters:
           artifactName: $(artifactName)
           pythonVersion: $(pythonVersion)
-          operatingSystem: 'ubuntu-16.04'
+          operatingSystem: 'ubuntu-18.04'
   - job:
     displayName: MacOS
     pool:
@@ -219,7 +188,7 @@ stages:
   - job:
     displayName: Typecheck
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-18.04'
     steps:
       - task: UsePythonVersion@0
         inputs:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -210,8 +210,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         inputs:
           artifactName: 'drop'
-          patterns: '**/*.whl'
-                    '**/*.tar.gz'
+          patterns: '**/*.(whl|tar.gz)'
           path: $(Pipeline.Workspace)
       - task: TwineAuthenticate@1
         inputs:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -121,8 +121,7 @@ stages:
             patterns: '**/*.tar.gz'
             path: $(Pipeline.Workspace)
 
-        - script: 'cd $(Pipeline.Workspace)'
-        - script: 'pip install anonlink-*.tar.gz'
+        - script: pip install anonlink --no-index --no-binary anonlink -f $(Pipeline.Workspace)'
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -98,6 +98,38 @@ stages:
             PathtoPublish: 'sdist/dist'
             ArtifactName: 'drop'
 
+- stage: TestSdistOnWinX86
+  displayName: testing if sdist can be compiled
+  dependsOn: [sdist]
+  jobs:
+    - job: winx86
+      displayName: testing on WinX86
+      pool:
+        vmImage: 'vs2017-win2016'
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.9'
+            architecture: x86
+        - script: |
+            python -m pip install --upgrade pip
+            pip install -U pytest-azurepipelines -r requirements.txt
+          displayName: 'Install testing requirements'
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: 'drop'
+            patterns: '**/*.tar.gz'
+            path: $(Pipeline.Workspace)
+
+        - script: |
+            pip install anonlink --no-index -f $(Pipeline.Workspace)
+          displayName: 'Install anonlink sdist'
+        - script: |
+            # Delete the source code folder to ensure we test only the installed wheel
+            rm -fr anonlink
+            pytest -W ignore::DeprecationWarning
+          displayName: 'pytest'
+
 - stage: test
   displayName: Unit tests
   dependsOn: ['wheels']

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -77,6 +77,7 @@ stages:
 
 - stage: sdist
   displayName: Build source distribution
+  dependsOn: []
   jobs:
     - job: sdist
       displayName: build source distribution
@@ -94,7 +95,7 @@ stages:
             targetFolder: 'sdist'
         - task: PublishBuildArtifacts@1
           inputs:
-            PathtoPublish: 'sdist'
+            PathtoPublish: 'sdist/dist'
             ArtifactName: 'drop'
 
 - stage: test

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -77,22 +77,25 @@ stages:
 
 - stage: sdist
   displayName: Build source distribution
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '3.9'
-    - script: |
-        python setup.py sdist
-      displayName: 'Artifact creation'
-    - task: CopyFiles@2
-      inputs:
-        targetFolder: 'sdist'
-    - task: PublishBuildArtifacts@1
-      inputs:
-        PathtoPublish: 'sdist'
-        ArtifactName: 'drop'
+  jobs:
+    - job: sdist
+      displayName: build source distribution
+      pool:
+        vmImage: 'ubuntu-16.04'
+      steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '3.9'
+        - script: |
+            python setup.py sdist
+          displayName: 'Artifact creation'
+        - task: CopyFiles@2
+          inputs:
+            targetFolder: 'sdist'
+        - task: PublishBuildArtifacts@1
+          inputs:
+            PathtoPublish: 'sdist'
+            ArtifactName: 'drop'
 
 - stage: test
   displayName: Unit tests

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -121,7 +121,7 @@ stages:
             patterns: '**/*.tar.gz'
             path: $(Pipeline.Workspace)
 
-        - script: pip install anonlink --no-index --no-binary anonlink -f file://$(Pipeline.Workspace)'
+        - script: pip install anonlink-0.14.0.tar.gz
           displayName: 'Install anonlink sdist'
         - script: |
             # Delete the source code folder to ensure we test only the installed wheel

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Information Analysis",
         "Topic :: Security :: Cryptography",


### PR DESCRIPTION
I added a stage to the CI that builds the source distribution and publishes it to the 'drop' artifact.
And modified the publish to test feed section to include the source dist.

Currently, the release pipeline only publishes the wheel files. We also need to publish the source distribution though.

Additionally, the source distribution was incomplete, as the manifest file was not up to date. 

And to round it all off, I also updated the ubuntu images in the CI script, as 16.04 is quite old now. (fixes #385)