### PR TITLE
Deallocate array with delete []

### DIFF
--- a/anonlink/similarities/dice.cpp
+++ b/anonlink/similarities/dice.cpp
@@ -654,7 +654,7 @@ extern "C"
                     push_score(score, j);
                 }
             }
-            delete andbuffer;
+            delete [] andbuffer;
 
         }
 


### PR DESCRIPTION
Was having a look at a code scanning tool and it had a suggestion to avoid a memory leak. I'm not above taking advice from robots so here we are.

![image](https://user-images.githubusercontent.com/855189/161474471-910833d8-3d84-4bd3-8ea3-23fa38c17dd6.png)
