### PR TITLE
Prepare patch release 0.15.1

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.11.1
         # to supply options, put them in 'env', like:
         env:
          CIBW_SKIP: '*-win32 *i686'

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.8", "3.9", "3.10"]
         
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,6 @@
     :target: https://dev.azure.com/data61/Anonlink/_build/latest?definitionId=3&branchName=main
 
 
-
 .. image:: https://codecov.io/gh/data61/anonlink/branch/main/graph/badge.svg
     :target: https://codecov.io/gh/data61/anonlink
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-bitarray==2.5.1
+bitarray==2.6.0
 clkhash==0.16.1
 Cython==0.29.32
 hypothesis==6.9.2
 pytest>=7.0.1
 pytest-cov==3.0.0
-numpy==1.22.3; python_version >= '3.8'
+numpy==1.23.4; python_version >= '3.8'
 numpy==1.19.5; python_version < '3.8'
 mypy-extensions==0.4.3

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ else:
 here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = [
-        "bitarray>=2.4.0",
+        "bitarray>=2.5",
         "numpy>=1.19",
         "mypy-extensions>=0.4",
-        "Cython>=0.29.10"
+        "Cython>=0.29"
     ]
 
 test_requirements = [
@@ -68,7 +68,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink",
-    version='0.15.0',
+    version='0.15.1',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',
@@ -96,7 +96,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: Microsoft :: Windows",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Updates dependencies used in testing to latest versions, updates to latest version of `cibuildwheel`. 

Drops support for Python 3.7