### PR TITLE
Function to compute Dice coefficients of bitarray pairs

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-latest, windows-latest, ubuntu-20.04]
         python: ["3.8", "3.9", "3.10", "3.11"]
         
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.15.3
+======
+
+- Added function to compute Dice coefficients of bitarray pairs. #567
+
 0.15.2
 ======
 

--- a/anonlink/similarities/__init__.py
+++ b/anonlink/similarities/__init__.py
@@ -10,7 +10,8 @@ implemented. These work on binary strings. However, other similarity
 functions are possible as well.
 """
 
-from anonlink.similarities._dice_python import dice_coefficient_python
+from anonlink.similarities._dice_python import (dice_coefficient_python,
+                                                dice_coefficient_pairs_python)
 from anonlink.similarities._smc import (hamming_similarity,
                                         simple_matching_coefficient)
 

--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -84,7 +84,7 @@ def dice_coefficient_python(
 def dice_coefficient_pairs_python(
         datasets: Sequence[Tuple[bitarray, bitarray]]
 ):
-    """Find Dice Sorensen coefficients of bitarray pairs.
+    """Find Dice coefficients of bitarray pairs.
 
     This version is written in Python, so it does not rely on
     architecture-specific instructions. It may be slower than an

--- a/anonlink/similarities/_dice_python.py
+++ b/anonlink/similarities/_dice_python.py
@@ -2,6 +2,7 @@ from array import array
 from itertools import repeat
 from typing import Iterable, Optional, Sequence, Tuple
 
+import numpy as np
 from bitarray import bitarray
 
 from anonlink.similarities._utils import (sort_similarities_inplace,
@@ -77,3 +78,43 @@ def dice_coefficient_python(
     sort_similarities_inplace(result_sims, result_indices0, result_indices1)
     
     return result_sims, (result_indices0, result_indices1)
+
+
+
+def dice_coefficient_pairs_python(
+        datasets: Sequence[Tuple[bitarray, bitarray]]
+):
+    """Find Dice Sorensen coefficients of bitarray pairs.
+
+    This version is written in Python, so it does not rely on
+    architecture-specific instructions. It may be slower than an
+    accelerated version.
+
+    A similarity is computed for every pair of bitarrays in the input
+    datasets, the similarity for each pair is returned as a floating-point
+    value.
+
+    :param datasets: A sequence of candidate pairs. Each pair in a tuple
+        of bitarrays.
+
+    :return: Similarity scores for every input pair as an array of
+        floating-point values.
+    """
+    candidate_pair_count = len(datasets)
+
+    # Preallocate the result array.
+    result_sims = np.zeros(candidate_pair_count, dtype=np.float64)
+
+    for i, (f0, f1) in enumerate(datasets):
+        f0_count = f0.count()
+        f1_count = f1.count()
+        combined_count = f0_count + f1_count
+
+        if combined_count:
+            score: float = (2.0 * (f0 & f1).count() / combined_count)
+        else:  # Avoid division by zero.
+            score = 0.0
+
+        result_sims[i] = score
+
+    return result_sims

--- a/projects/similarity_stream/main.py
+++ b/projects/similarity_stream/main.py
@@ -1,0 +1,6 @@
+from typing import Sequence, Tuple, Optional, Iterable
+
+import numpy as np
+from bitarray import bitarray
+
+

--- a/projects/similarity_stream/main.py
+++ b/projects/similarity_stream/main.py
@@ -1,6 +1,0 @@
-from typing import Sequence, Tuple, Optional, Iterable
-
-import numpy as np
-from bitarray import bitarray
-
-

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name="anonlink",
-    version='0.15.2',
+    version='0.15.3',
     description='Anonymous linkage using cryptographic hashes and bloom filters',
     long_description=readme,
     long_description_content_type='text/x-rst',

--- a/tests/test_similarity_dice.py
+++ b/tests/test_similarity_dice.py
@@ -4,6 +4,7 @@ from clkhash import bloomfilter, randomnames
 from clkhash.key_derivation import generate_key_lists
 from hypothesis import given, strategies
 
+import anonlink.similarities
 from anonlink import similarities
 
 FLOAT_ARRAY_TYPES = 'fd'
@@ -257,6 +258,21 @@ class TestBloomFilterComparison:
         assert sims.typecode in FLOAT_ARRAY_TYPES
         assert (rec_is0.typecode in UINT_ARRAY_TYPES
                 and rec_is1.typecode in UINT_ARRAY_TYPES)
+
+    def test_candidate_stream_right_low(self):
+        datasets = list(zip(*[[bitarray('01001011') * 8],
+                    [bitarray('00000000') * 8]]))
+        sims = anonlink.similarities.dice_coefficient_pairs_python(datasets)
+        assert len(sims) == 1
+        assert all(s == 0.0 for s in sims)
+
+    def test_candidate_stream_all_low(self):
+        datasets = list(zip(*[[bitarray('00000000') * 8],
+                    [bitarray('00000000') * 8]]))
+        sims = anonlink.similarities.dice_coefficient_pairs_python(datasets)
+
+        assert len(sims) == 1
+        assert all(s == 0.0 for s in sims)
 
     @pytest.mark.parametrize('sim_fun', SIM_FUNS)
     def test_order(self, sim_fun):


### PR DESCRIPTION
Anonlink's similarity functions currently compare every possible candidate pair via a cartesian product, and works really well with a fairly large number of encodings. With very fine grained blocking such as p-sig you may have many small blocks. Anonlink doesn't do to well with this as we optimized the comparison function for high throughput with large batches - not for low latency with tiny batches.

To get higher throughput it is tempting to merge together a bunch of these small blocks before calling anonlink - however this approach adds candidate pairs that were not explicitly in the blocking rules - skewing results and performing unnecessary work.

This PR adds a function in `anonlink.similarities` to compute the Dice coefficient on pairs of bitarrays. If useful we could also implement an accelerated version.