### PR TITLE
Remove macOS from Azure Pipeline

### DIFF
--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -11,4 +11,6 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs: {pathtoPublish: 'wheelhouse'}
 - task: PublishPipelineArtifact@1
-  inputs: {targetPath: 'wheelhouse', artifact: ${{ parameters.artifactName }}}
+  inputs:
+    targetPath: 'wheelhouse'
+    artifact: ${{ parameters.artifactName }}

--- a/.azurePipeline/cibuildwheel_steps.yml
+++ b/.azurePipeline/cibuildwheel_steps.yml
@@ -1,3 +1,5 @@
+parameters:
+  artifactName: 'wheels'
 
 steps:
 - bash: |
@@ -9,4 +11,4 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs: {pathtoPublish: 'wheelhouse'}
 - task: PublishPipelineArtifact@1
-  inputs: {targetPath: 'wheelhouse'}
+  inputs: {targetPath: 'wheelhouse', artifact: ${{ parameters.artifactName }}}

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -51,18 +51,6 @@ stages:
         - template: .azurePipeline/cibuildwheel_steps.yml
           parameters:
             artifactName: 'wheels.linux38'
-    - job: macos
-      displayName: MacOS
-      pool:
-        vmImage: 'macOS-12'
-      variables:
-        MACOSX_DEPLOYMENT_TARGET: '12'
-      steps:
-        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
-        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.9', architecture: x64}}
-        - template: .azurePipeline/cibuildwheel_steps.yml
-          parameters:
-            artifactName: 'wheels.macos'
     - job: windows
       displayName: Windows
       pool:
@@ -119,27 +107,6 @@ stages:
           artifactName: $(artifactName)
           pythonVersion: $(pythonVersion)
           operatingSystem: 'ubuntu-20.04'
-  - job:
-    displayName: MacOS
-    pool:
-      vmImage: 'macOS-12'
-    strategy:
-      matrix:
-        Python3.8:
-          pythonVersion: '3.8'
-          artifactName: 'wheels.macos'
-          artifactPattern: '**/*cp38*.whl'
-        Python3.9:
-          pythonVersion: '3.9'
-          artifactName: 'wheels.macos'
-          artifactPattern: '**/*cp39*.whl'
-    steps:
-      - template: .azurePipeline/unittest_wheel_steps.yml
-        parameters:
-          artifactName: $(artifactName)
-          artifactPattern: $(artifactPattern)
-          pythonVersion: $(pythonVersion)
-          operatingSystem: 'macOS-12'
   - job:
     displayName: Windows
     pool:

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -27,6 +27,8 @@ stages:
       steps:
         - { task: UsePythonVersion@0, inputs: { versionSpec: '3.10', architecture: x64 } }
         - template: .azurePipeline/cibuildwheel_steps.yml
+          parameters:
+            artifactName: 'wheels.linux310'
     - job: linux_39
       displayName: Linux + Python3.9
       pool:
@@ -36,6 +38,8 @@ stages:
       steps:
         - { task: UsePythonVersion@0, inputs: { versionSpec: '3.9', architecture: x64 } }
         - template: .azurePipeline/cibuildwheel_steps.yml
+          parameters:
+            artifactName: 'wheels.linux39'
     - job: linux_38
       displayName: Linux + Python3.8
       pool:
@@ -45,6 +49,8 @@ stages:
       steps:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
         - template: .azurePipeline/cibuildwheel_steps.yml
+          parameters:
+            artifactName: 'wheels.linux38'
     - job: macos
       displayName: MacOS
       pool:
@@ -55,6 +61,8 @@ stages:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.9', architecture: x64}}
         - template: .azurePipeline/cibuildwheel_steps.yml
+          parameters:
+            artifactName: 'wheels.macos'
     - job: windows
       displayName: Windows
       pool:
@@ -63,6 +71,8 @@ stages:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.9', architecture: x64}}
         - template: .azurePipeline/cibuildwheel_steps.yml
+          parameters:
+            artifactName: 'wheels.windows'
 
 - stage: sdist
   displayName: Build source distribution

--- a/azurePipeline.yml
+++ b/azurePipeline.yml
@@ -48,9 +48,9 @@ stages:
     - job: macos
       displayName: MacOS
       pool:
-        vmImage: 'macOS-10.15'
+        vmImage: 'macOS-12'
       variables:
-        MACOSX_DEPLOYMENT_TARGET: '10.15'
+        MACOSX_DEPLOYMENT_TARGET: '12'
       steps:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.9', architecture: x64}}
@@ -112,7 +112,7 @@ stages:
   - job:
     displayName: MacOS
     pool:
-      vmImage: 'macOS-10.15'
+      vmImage: 'macOS-12'
     strategy:
       matrix:
         Python3.8:
@@ -129,7 +129,7 @@ stages:
           artifactName: $(artifactName)
           artifactPattern: $(artifactPattern)
           pythonVersion: $(pythonVersion)
-          operatingSystem: 'macOS-10.15'
+          operatingSystem: 'macOS-12'
   - job:
     displayName: Windows
     pool:


### PR DESCRIPTION
Azure isn't happy:
![image](https://user-images.githubusercontent.com/855189/235379052-19f3209e-7f79-401d-8c76-170fe080b9f1.png)

Note we do also run unit tests on latest macOS using GitHub actions so if this proves difficult I suggest we just remove the Azure pipeline.